### PR TITLE
Hotfix of the Officer Dossier View Creation

### DIFF
--- a/mdbi/tools/sce_db_setup_v0.js
+++ b/mdbi/tools/sce_db_setup_v0.js
@@ -866,6 +866,18 @@ if (arg === "--help") {
 								}
 							},
 							{
+								"$match": {
+									"$or": [
+										{
+											"memPlanData.level": 0
+										},
+										{
+											"memPlanData.level": 1
+										}
+									]
+								}
+							},
+							{
 								"$lookup": {
 									"from": "ClearanceLevel",
 									"localField": "memPlanData.level",


### PR DESCRIPTION
This commit is a hotfix taking place after pull request 21 was integrated into dev. It's aim is to correct the invalid aggregation pipeline specification given to the officer dossier view creation.s

Below is a list of changes:

mdbi/tools/sce_db_setup_v0.js:
	- Modified the "addOfficerDossierView" promise to have a properly filtering "$match" stage in the aggregation pipeline that excludes all members whose "MembershipData.level" is not that of an admin or officer. Without it, the officer dossier view would also include all non-officer members.