### PR TITLE
Hotfix on Core Access View

### DIFF
--- a/mdbi/tools/sce_db_setup_v0.js
+++ b/mdbi/tools/sce_db_setup_v0.js
@@ -943,6 +943,18 @@ if (arg === "--help") {
 								}
 							},
 							{
+								"$match": {
+									"$or": [
+										{
+											"memPlanData.level": 0
+										},
+										{
+											"memPlanData.level": 1
+										}
+									]
+								}
+							},
+							{
 								"$replaceRoot": {
 									"newRoot": {
 										"memberID": "$memberID",


### PR DESCRIPTION
This commit is a hotfix taking place after pull request 21 was integrated into dev. It's aim is to correct the invalid aggregation pipeline specification given to the core access view creation.

Below is a list of changes:

mdbi/tools/sce_db_setup_v0.js:
	- Modified the "addCoreAccessView" promise to have a properly filtering "$match" stage in the pipeline that excludes all members whose "MembershipData.level" is not that of an admin or officer. Without it, the core access view would also include all non-officer members. Adding this extra filtering implies that the "/core/login" endpoint need only search for an entry in this view incorporating a 2-field fatch (i.e. password and username), without having to worry about checking user levels.