### PR TITLE
Added NPM Script for Running Frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "mocha",
     "start": "react-scripts build && node server.js | react-scripts start",
+    "frontend": "react-scripts start",
     "deploy": "git pull && npm install && pm2 stop database api app && pm2 delete database api app && pm2 start mongod --name \"database\" && npm run build && pm2 start npm --name \"app\" -- start && pm2 start npm \"app\" -- run dev",
     "lint": "prettier 'utils/**/*.js' 'static/js/**/*.js' '__tests__/**/*.js' 'components/**/*.js' 'pages/**/*.js' 'public/**/*.js' '*.js' --write --single-quote --no-semi && standard --fix"
   },


### PR DESCRIPTION
Now when the user enters `npm run frontend`, only `react-scripts start` will run, instead of the
commands specified in `npm run start`.