### PR TITLE
Added Replacement Navbars

### DIFF
--- a/src/Components/Navbar/AdminNavbar.js
+++ b/src/Components/Navbar/AdminNavbar.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import { Navbar, NavbarBrand, NavLink, Nav } from 'reactstrap'
+
+import './admin-navbar.css'
+
+export default function AdminNavbar (props) {
+  const navbarLinks = [
+    { title: 'Home', route: '/' },
+    { title: 'Overview', route: '/dashboard' },
+    { title: 'Admin', route: '/admin', restricted: true },
+    { title: 'Officer Tools', route: '/officer-tools' },
+    { title: 'Member Manager', route: '/member-manager' },
+    { title: 'Event Manager', route: '/event-manager' },
+    { title: '3DConsole', route: '/3DConsole' }
+  ]
+
+  return (
+    <Navbar>
+      <NavbarBrand href='/'>
+        Software & Computer Engineering Society &nbsp;
+      </NavbarBrand>
+      <Nav>
+        {navbarLinks.map((link, index) => {
+          const navlink = (
+            <NavLink key={index} title={link.title} to={link.route}>
+              {link.title}
+            </NavLink>
+          )
+          // If the link has restricted access, return it based on the
+          // condition that the user has admin priviledge. Otherwise,
+          // just return the link.
+          return link.restricted
+            ? props.user && props.user.accessLevel === 2 && navlink
+            : navlink
+        })}
+        <div onClick={() => props.handleLogout()} className='nav-button'>
+          <svg style={{ width: '18px', height: '18px' }} viewBox='0 0 24 24'>
+            <path d='M17,17.25V14H10V10H17V6.75L22.25,12L17,17.25M13,2A2,2 0 0,1 15,4V8H13V4H4V20H13V16H15V20A2,2 0 0,1 13,22H4A2,2 0 0,1 2,20V4A2,2 0 0,1 4,2H13Z' />
+          </svg>
+          Logout
+        </div>
+      </Nav>
+    </Navbar>
+  )
+}

--- a/src/Components/Navbar/NavBarWrapper.js
+++ b/src/Components/Navbar/NavBarWrapper.js
@@ -1,0 +1,29 @@
+import React from 'react'
+
+import UserNavbar from './UserNavbar'
+import AdminNavbar from './AdminNavbar'
+
+function NavBarWrapper ({
+  enableAdminNavbar = false,
+  component: Component,
+  ...appProps
+}) {
+  function handleLogout () {
+    appProps.setAuthenticated(false)
+    window.localStorage.removeItem('jwtToken')
+    window.location.reload()
+  }
+
+  return (
+    <div>
+      {enableAdminNavbar ? (
+        <AdminNavbar {...appProps} handleLogout={handleLogout} />
+      ) : (
+        <UserNavbar {...appProps} handleLogout={handleLogout} />
+      )}
+      <Component />
+    </div>
+  )
+}
+
+export default NavBarWrapper

--- a/src/Components/Navbar/UserNavbar.js
+++ b/src/Components/Navbar/UserNavbar.js
@@ -1,0 +1,161 @@
+import React, { Component } from 'react'
+import './navbar.css'
+import {
+  Navbar,
+  NavbarBrand,
+  Nav,
+  NavItem,
+  NavLink,
+  UncontrolledDropdown,
+  DropdownToggle,
+  DropdownMenu,
+  DropdownItem
+} from 'reactstrap'
+
+import 'bootstrap/dist/css/bootstrap.min.css'
+
+class UserNavBar extends Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      isLoggedIn: this.props.authenticated,
+      user: this.props.user,
+      icons: [
+        {
+          link: [
+            'https://www.linkedin.com/company',
+            '/sjsu-software-computer-engineering-society/'
+          ].join(''),
+          vector: [
+            'M19,3A2,2 0 0,1 21,5V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V5A',
+            '2,2 0 0,1 5,3H19M18.5,18.5V13.2A3.26,3.26 0 0,0 15.24,9.94C14.39,9.',
+            '94 13.4,10.46 12.92,11.24V10.13H10.13V18.5H12.92V13.57C12.92,12.8 ',
+            '13.54,12.17 14.31,12.17A1.4,1.4 0 0,1 15.71,13.57V18.5H18.5M6.88,8',
+            '.56A1.68,1.68 0 0,0 8.56,6.88C8.56,5.95 7.81,5.19 6.88,5.19A1.69,1',
+            '.69 0 0,0 5.19,6.88C5.19,7.81 5.95,8.56 6.88,8.56M8.27,18.5V10.13H',
+            '5.5V18.5H8.27Z'
+          ].join('')
+        },
+        {
+          link: 'https://www.facebook.com/sjsusce/',
+          vector: [
+            'M5,3H19A2,2 0 0,1 21,5V19A2,2 0 0,1 19,21H5A2,2 0 0,1 ',
+            '3,19V5 A2,2 0 0,1 5,3M18,5H15.5A3.5,3.5 0 0,0 12,8.5V11H10V14H1',
+            '2V21H15V14H18V11H15V9A1,1 0 0,1 16,8H18V5Z'
+          ].join('')
+        }
+      ],
+      unauthedRoutes: [
+        { title: 'Snacks & Food', route: '/' },
+        { title: 'Events', route: '/events' },
+        { title: 'Snacks & Food', route: '/Team' }
+      ]
+    }
+    this.handleLogout = this.handleLogout.bind(this)
+  }
+
+  handleLogout () {
+    this.props.handleLogout()
+  }
+
+  render () {
+    return (
+      <div className='sce-nav'>
+        <Navbar light expand='md'>
+          <NavbarBrand href='/'>
+            Software & Computer Engineering Society &nbsp;
+          </NavbarBrand>
+          {this.state.icons.map((icon, index) => {
+            return (
+              <a key={index} href={icon.link}>
+                <svg width='35px' height='35px' viewBox='0 0 24 24'>
+                  <path fill='#757575' d={icon.vector} />
+                </svg>
+              </a>
+            )
+          })}
+          <Nav className='ml-auto' navbar>
+            <UncontrolledDropdown nav inNavbar>
+              <DropdownToggle nav caret>
+                Student Resources
+              </DropdownToggle>
+              <DropdownMenu right>
+                <DropdownItem href='/labkits'>Lab Kits</DropdownItem>
+                <DropdownItem href='https://docs.google.com/forms/d/e/1FAIpQLSfAKfUnblxOZ0r3BjMY6xe_0g2zC7v3OfaadyvF-Ste1eL28A/viewform'>
+                  Microsoft Imagine
+                </DropdownItem>
+              </DropdownMenu>
+            </UncontrolledDropdown>
+            {this.state.user && this.state.user.accessLevel >= 1 && (
+              <UncontrolledDropdown nav inNavbar>
+                <DropdownToggle nav caret>
+                  Printing
+                </DropdownToggle>
+                <DropdownMenu right>
+                  <DropdownItem href='/2DPrinting'>2D Printing</DropdownItem>
+                  <DropdownItem href='/3DPrintingForm'>
+                    3D Printing
+                  </DropdownItem>
+                </DropdownMenu>
+              </UncontrolledDropdown>
+            )}
+            {this.state.unauthedRoutes.map((link, index) => {
+              return (
+                <NavItem key={index}>
+                  <NavLink href={link.route}>{link.title}</NavLink>
+                </NavItem>
+              )
+            })}
+            <UncontrolledDropdown nav inNavbar>
+              <DropdownToggle nav caret>
+                Join Us!
+              </DropdownToggle>
+              <DropdownMenu right>
+                <DropdownItem href='/register'>
+                  Membership Application
+                </DropdownItem>
+              </DropdownMenu>
+            </UncontrolledDropdown>
+            {this.state.isLoggedIn && this.state.user ? (
+              <UncontrolledDropdown nav inNavbar>
+                <DropdownToggle nav caret>
+                  <svg
+                    style={{ width: '30px', height: '30px' }}
+                    viewBox='0 0 24 24'
+                  >
+                    <path
+                      fill='#AAAAAA'
+                      d='M12,19.2C9.5,19.2 7.29,17.92 6,16C6.03,14 10,12.9 12,12.9C14,12.9 17.97,14 18,16C16.71,17.92 14.5,19.2 12,19.2M12,5A3,3 0 0,1 15,8A3,3 0 0,1 12,11A3,3 0 0,1 9,8A3,3 0 0,1 12,5M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12C22,6.47 17.5,2 12,2Z'
+                    />
+                  </svg>
+                  {this.state.user.name}
+                </DropdownToggle>
+                <DropdownMenu right>
+                  <DropdownItem href='/profile'>Profile</DropdownItem>
+                  {this.state.user.accessLevel >= 1 && (
+                    <DropdownItem href='/dashboard'>Admin</DropdownItem>
+                  )}
+                  <DropdownItem>
+                    <div onClick={this.handleLogout}>
+                      <svg
+                        style={{ width: '18px', height: '18px' }}
+                        viewBox='0 0 24 24'
+                      >
+                        <path d='M17,17.25V14H10V10H17V6.75L22.25,12L17,17.25M13,2A2,2 0 0,1 15,4V8H13V4H4V20H13V16H15V20A2,2 0 0,1 13,22H4A2,2 0 0,1 2,20V4A2,2 0 0,1 4,2H13Z' />
+                      </svg>
+                      Logout
+                    </div>
+                  </DropdownItem>
+                </DropdownMenu>
+              </UncontrolledDropdown>
+            ) : (
+              <NavLink href='/login'>Login</NavLink>
+            )}
+          </Nav>
+        </Navbar>
+      </div>
+    )
+  }
+}
+
+export default UserNavBar

--- a/src/Components/Navbar/admin-navbar.css
+++ b/src/Components/Navbar/admin-navbar.css
@@ -1,0 +1,26 @@
+header {
+  width: 100%;
+  height: 100%;
+  background-size:cover;
+  overflow:hidden;
+  display: flex !important;
+  justify-content: flex-end;
+  background: #EFEFEF;
+  align-items: center;
+}
+
+header a, .nav-button {
+  padding: 18px 36px;
+  color: #515151;
+  transition: color 0.2s;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+}
+header a:hover {
+  color: #000000;
+}
+.active-nav-link {
+  color: #FF0000;
+}

--- a/test/frontend/AdminNavbar.test.js
+++ b/test/frontend/AdminNavbar.test.js
@@ -1,0 +1,35 @@
+/* global describe it */
+import 'jsdom-global/register'
+import React from 'react'
+import Enzyme, { mount } from 'enzyme'
+import { expect } from 'chai'
+
+import AdminNavbar from '../../src/Components/Navbar/AdminNavbar'
+import Adapter from 'enzyme-adapter-react-16'
+import { NavbarBrand, NavLink } from 'reactstrap'
+
+Enzyme.configure({ adapter: new Adapter() })
+
+const adminAppProps = {
+  user: { accessLevel: 2 }
+}
+
+describe('<AdminNavbar />', () => {
+  it('Should render a <NavbarBrand /> with the SCE Title', () => {
+    const wrapper = mount(<AdminNavbar />)
+    expect(
+      wrapper
+        .find(NavbarBrand)
+        .prop('children')
+        .toString() === 'Software & Computer Engineering Society  '
+    )
+  })
+  it('Should render 6 <NavLink /> tags with officer Credentials', () => {
+    const wrapper = mount(<AdminNavbar />)
+    expect(wrapper.find(NavLink)).to.have.lengthOf(6)
+  })
+  it('Should render 7 <NavLink /> tags with admin Credentials', () => {
+    const wrapper = mount(<AdminNavbar {...adminAppProps} />)
+    expect(wrapper.find(NavLink)).to.have.lengthOf(7)
+  })
+})

--- a/test/frontend/NavBarWrapper.test.js
+++ b/test/frontend/NavBarWrapper.test.js
@@ -1,0 +1,34 @@
+/* global describe it */
+import 'jsdom-global/register'
+import React from 'react'
+import Enzyme, { mount } from 'enzyme'
+import { expect } from 'chai'
+
+import NavBarWrapper from '../../src/Components/Navbar/NavBarWrapper'
+import UserNavbar from '../../src/Components/Navbar/UserNavbar'
+import AdminNavbar from '../../src/Components/Navbar/AdminNavbar'
+import NotFoundPage from '../../src/Pages/NotFoundPage/NotFoundPage'
+import Adapter from 'enzyme-adapter-react-16'
+
+Enzyme.configure({ adapter: new Adapter() })
+
+const adminAppProps = {
+  component: NotFoundPage,
+  enableAdminNavbar: true
+}
+const userAppProps = {
+  component: NotFoundPage
+}
+
+describe('<NavBarWrapper />', () => {
+  it('Should by default render a <UserNavbar /> with the component', () => {
+    const wrapper = mount(<NavBarWrapper {...userAppProps} />)
+    expect(wrapper.find(UserNavbar)).to.have.lengthOf(1)
+    expect(wrapper.find(NotFoundPage).children()).to.have.lengthOf(1)
+  })
+  it('Should render a <AdminNavbar /> with the enableAdminNavbar prop', () => {
+    const wrapper = mount(<NavBarWrapper {...adminAppProps} />)
+    expect(wrapper.find(AdminNavbar)).to.have.lengthOf(1)
+    expect(wrapper.find(NotFoundPage).children()).to.have.lengthOf(1)
+  })
+})

--- a/test/frontend/UserNavbar.test.js
+++ b/test/frontend/UserNavbar.test.js
@@ -1,0 +1,74 @@
+/* global describe it */
+import 'jsdom-global/register'
+import React from 'react'
+import Enzyme, { mount } from 'enzyme'
+import { expect } from 'chai'
+
+import UserNavbar from '../../src/Components/Navbar/UserNavbar'
+import Adapter from 'enzyme-adapter-react-16'
+import { Navbar, Nav, NavLink, UncontrolledDropdown } from 'reactstrap'
+
+Enzyme.configure({ adapter: new Adapter() })
+
+const authenticatedAppProps = {
+  authenticated: true,
+  user: { accessLevel: 2 }
+}
+
+function getDropdownDetails (dropdown, index = 0) {
+  return dropdown.props.children[index].props.children
+}
+
+describe('<UserNavbar />', () => {
+  it('Should render a <Navbar /> component with one child', () => {
+    const wrapper = mount(<UserNavbar />)
+    expect(wrapper.find(Navbar)).to.have.lengthOf(1)
+  })
+  it('Should render four <NavLink /> tags for unauthenticated routes', () => {
+    const wrapper = mount(<UserNavbar />)
+    expect(wrapper.find(NavLink)).to.have.lengthOf(4)
+    expect(wrapper.find(Nav).children()).to.have.lengthOf(1)
+  })
+  it(
+    'Should render two <UncontrolledDropdown /> tags for' +
+      ' the unauthenticated user',
+    () => {
+      const wrapper = mount(<UserNavbar />)
+      expect(wrapper.find(UncontrolledDropdown)).to.have.lengthOf(2)
+    }
+  )
+  it(
+    'The two <UncontrolledDropdown /> tags for' +
+      ' the unauthenticated user should be for student resources and ' +
+      'to join sce',
+    () => {
+      const wrapper = mount(<UserNavbar />)
+      const dropdowns = wrapper.find(UncontrolledDropdown)
+      expect(getDropdownDetails(dropdowns.get(0))).to.equal('Student Resources')
+      expect(getDropdownDetails(dropdowns.get(1))).to.equal('Join Us!')
+    }
+  )
+  it(
+    'Should render four <UncontrolledDropdown /> tags for' +
+      ' the authenticated user',
+    () => {
+      const wrapper = mount(<UserNavbar {...authenticatedAppProps} />)
+      expect(wrapper.find(UncontrolledDropdown)).to.have.lengthOf(4)
+    }
+  )
+  it(
+    'The four <UncontrolledDropdown /> tags for' +
+      ' authenticated users should be for student resources, printing, ' +
+      'to join sce and a drop down of account options',
+    () => {
+      const wrapper = mount(<UserNavbar {...authenticatedAppProps} />)
+      const dropdowns = wrapper.find(UncontrolledDropdown)
+      expect(getDropdownDetails(dropdowns.get(0))).to.equal('Student Resources')
+      expect(getDropdownDetails(dropdowns.get(1))).to.equal('Printing')
+      expect(getDropdownDetails(dropdowns.get(2))).to.equal('Join Us!')
+      expect(
+        getDropdownDetails(dropdowns.get(3), 1)[0].props.children
+      ).to.equal('Profile')
+    }
+  )
+})


### PR DESCRIPTION
These navbars will be used when routing is refactored. `NavBarWrapper` will wrap each component so that <Layout> is no longer needed to wrap every page in Core-v4.

`UserNavbar` will replace the `<Layout>` component, and `AdminNavbar` will replace the `<Dashboard>` component.

The implementation of these components will be in #171. We must merge this first.