### PR TITLE
Added Config Environment Variable to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
 services:
   - mongodb
 install:
+ - echo $ENCODED_CONFIG > .temp
+ - base64 --decode .temp > api/config/config.js
  - npm install
 script:
  - npm run api-test


### PR DESCRIPTION
Now the config.js file is hidden from public view, but will still allow builds to pass. We store the
encoded config file in travis and decode it when a build runs.