### PR TITLE
Fixed Signed Out Bug

### DIFF
--- a/src/APIFunctions/User.js
+++ b/src/APIFunctions/User.js
@@ -65,6 +65,7 @@ export async function checkIfUserIsSignedIn () {
       status.token = token
     })
     .catch(err => {
+      status.error = true
       status.responseData = err
     })
   return status


### PR DESCRIPTION
I didn't set the error field to true if the token wasn't properly verified. Now, the user will not
be able to access unauthorized pages if they have an expired token.