### PR TITLE
Added LED Sign Functionality

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,3 +1,3 @@
-const routes = ['3DPrintingForm', 'Event', 'officerManager', 'user', 'print']
+const routes = ['3DPrintingForm', 'Event', 'officerManager', 'user', 'print', 'LedSign']
 
 module.exports = routes

--- a/api/routes/LedSign.js
+++ b/api/routes/LedSign.js
@@ -1,0 +1,30 @@
+const express = require('express')
+const router = express.Router()
+const {
+  healthCheck,
+  updateSignText
+} = require('../../printingRPC/client/ledsign/led_sign_client')
+const { OK, NOT_FOUND, BAD_REQUEST } = require('../constants').STATUS_CODES
+
+router.post('/updateSignText', async (req, res) => {
+  await updateSignText(req.body)
+    .then(response => {
+      return res.status(OK).send({ ...response })
+    })
+    .catch(err => {
+      return res.status(BAD_REQUEST).send({ ...err })
+    })
+})
+
+router.post('/healthCheck', async (req, res) => {
+  const { officerName } = req.body
+  await healthCheck(officerName)
+    .then(response => {
+      return res.status(OK).send({ ...response })
+    })
+    .catch(err => {
+      return res.status(NOT_FOUND).send({ ...err })
+    })
+})
+
+module.exports = router

--- a/src/APIFunctions/LedSign.js
+++ b/src/APIFunctions/LedSign.js
@@ -1,0 +1,58 @@
+import axios from 'axios'
+
+class ApiResponse {
+  constructor () {
+    this.error = false
+    this.responseData = null
+  }
+}
+
+/**
+ * Checks to see if the sign is accepting requests. This is done
+ * before any requests to update the sign can be made.
+ * @param {string} officerName The name of the officer requesting the sign
+ * @returns {Object} An object containing a boolean
+ */
+export async function healthCheck (officerName) {
+  let signResponse = new ApiResponse()
+  await axios
+    .post('api/LedSign/healthCheck', { officerName })
+    .then(res => {
+      signResponse.responseData = res.data
+    })
+    .catch(err => {
+      signResponse.responseData = err
+      signResponse.error = true
+    })
+  return signResponse
+}
+
+/**
+ * Add a new event.
+ * @param {Object} newEvent - The event that is to be added
+ * @param {string} newEvent.title - The title of the new event
+ * @param {(string|undefined)} newEvent.description - The description of the
+ * new event
+ * @param {string} newEvent.eventLocation - The location of the new event
+ * @param {string} newEvent.eventDate - The late of the new event
+ * @param {string} newEvent.startTime - The start time of the new event
+ * @param {string} newEvent.endTime - The end time of the new event
+ * @param {(string|undefined)} newEvent.eventCategory - The category of the new
+ * event
+ * @param {(string|undefined)} newEvent.imageURL - A URL of the image of the
+ * event
+ * @param {string} token - The user's jwt token for authentication
+ */
+export async function updateSignText (signData) {
+  let signResponse = new ApiResponse()
+  await axios
+    .post('api/LedSign/updateSignText', { ...signData })
+    .then(res => {
+      signResponse = res.data
+    })
+    .catch(err => {
+      signResponse.responseData = err
+      signResponse.error = true
+    })
+  return signResponse
+}

--- a/src/Components/Navbar/AdminNavbar.js
+++ b/src/Components/Navbar/AdminNavbar.js
@@ -15,6 +15,7 @@ export default function AdminNavbar (props) {
   const navbarLinks = [
     { title: 'Overview', route: '/dashboard' },
     { title: 'Event Manager', route: '/event-manager' },
+    { title: 'LED Sign', route: '/led-sign' },
     { title: '3DConsole', route: '/3DConsole' }
   ]
 

--- a/src/Pages/LedSign/LedSign.js
+++ b/src/Pages/LedSign/LedSign.js
@@ -1,0 +1,143 @@
+import React, { useState, useEffect } from 'react'
+import { healthCheck, updateSignText } from '../../APIFunctions/LedSign'
+import { Spinner, Input, Button, Container } from 'reactstrap'
+import './led-sign.css'
+
+function LedSign (props) {
+  const [signHealthy, setSignHealthy] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [text, setText] = useState('')
+  const [brightness, setBrightness] = useState(50)
+  const [scrollSpeed, setScrollSpeed] = useState(50)
+  const [backgroundColor, setBackgroundColor] = useState('#0000ff')
+  const [textColor, setTextColor] = useState('#00ff00')
+  const [borderColor, setBorderColor] = useState('#ff0000')
+  const [awaitingSignResponse, setAwaitingSignResponse] = useState(false)
+  const [requestSuccessful, setRequestSuccessful] = useState()
+
+  const inputArray = [
+    {
+      title: 'Sign Text:',
+      placeholder: 'Enter Text',
+      defaultValue: '',
+      type: 'text',
+      onChange: e => setText(e.target.value)
+    },
+    {
+      title: 'Background Color',
+      defaultValue: '#0000ff',
+      type: 'color',
+      onChange: e => setBackgroundColor(e.target.value)
+    },
+    {
+      title: 'Text Color',
+      defaultValue: '#00ff00',
+      type: 'color',
+      onChange: e => setTextColor(e.target.value)
+    },
+    {
+      title: 'Border Color',
+      defaultValue: '#ff0000',
+      type: 'color',
+      onChange: e => setBorderColor(e.target.value)
+    },
+    {
+      title: 'Brightness:',
+      defaultValue: '50',
+      min: '0',
+      max: '100',
+      step: '1',
+      type: 'range',
+      onChange: e => setBrightness(e.target.value)
+    },
+    {
+      title: 'Scroll Speed:',
+      defaultValue: '50',
+      min: '0',
+      max: '100',
+      step: '1',
+      type: 'range',
+      onChange: e => setScrollSpeed(e.target.value)
+    }
+  ]
+
+  async function handleSend () {
+    setAwaitingSignResponse(true)
+    const signResponse = await updateSignText({
+      text,
+      brightness,
+      scrollSpeed,
+      backgroundColor,
+      textColor,
+      borderColor
+    })
+    setRequestSuccessful(!signResponse.error)
+    setAwaitingSignResponse(false)
+  }
+
+  function renderRequestStatus () {
+    if (awaitingSignResponse || requestSuccessful === undefined) {
+      return <></>
+    } else if (requestSuccessful) {
+      return <p className='sign-available'>Sign successfully updated!</p>
+    } else {
+      return (
+        <p className='sign-unavailable'>The request failed. Try again later.</p>
+      )
+    }
+  }
+
+  useEffect(() => {
+    async function checkSignHealth () {
+      setLoading(true)
+      const status = await healthCheck(props.user.name)
+      if (status && !status.error) {
+        setSignHealthy(true)
+      } else {
+        setSignHealthy(false)
+      }
+      setLoading(false)
+    }
+    checkSignHealth(props.user.name)
+    // eslint-disable-next-line
+  }, [])
+
+  function renderSignHealth () {
+    if (loading) {
+      return <Spinner />
+    } else if (signHealthy) {
+      return <span className='sign-available'> Sign is up.</span>
+    } else {
+      return <span className='sign-unavailable'> Sign is down!</span>
+    }
+  }
+
+  return (
+    <div className='sign-wrapper'>
+      <Container>
+        <h1 className='sign-status'>
+          Sign Status:
+          {renderSignHealth()}
+        </h1>
+      </Container>
+      {inputArray.map((input, index) => {
+        return (
+          <div key={index} className='full-width'>
+            <label>{input.title}</label>
+            <Input disabled={loading || !signHealthy} {...input} />
+          </div>
+        )
+      })}
+      <Button
+        id='led-sign-send'
+        onClick={handleSend}
+        disabled={loading || !signHealthy || awaitingSignResponse}
+      >
+        {awaitingSignResponse ? <Spinner /> : 'Send'}
+      </Button>
+      {renderRequestStatus()}
+    </div>
+  )
+}
+
+export default LedSign

--- a/src/Pages/LedSign/led-sign.css
+++ b/src/Pages/LedSign/led-sign.css
@@ -1,0 +1,17 @@
+.sign-wrapper {
+  margin: auto;
+  width: 50%;
+  padding: 10px;
+}
+
+.sign-status {
+  width: 100%;
+}
+
+.sign-available {
+  color: green;
+}
+
+.sign-unavailable {
+  color: red;
+}

--- a/src/Routing.js
+++ b/src/Routing.js
@@ -9,6 +9,7 @@ import Overview from './Pages/Overview/Overview'
 import EventManager from './Pages/EventManager/EventManager'
 import Login from './Pages/Login/Login'
 import Profile from './Pages/Profile/MemberView/Profile'
+import LedSign from './Pages/LedSign/LedSign'
 
 import Home from './Pages/Home/Home.js'
 import NotFoundPage from './Pages/NotFoundPage/NotFoundPage'
@@ -48,6 +49,12 @@ export default function Routing ({ appProps }) {
     {
       Component: SolidsConsole,
       path: '/3DConsole',
+      allowedIf: userIsOfficerOrAdmin,
+      redirect: '/'
+    },
+    {
+      Component: LedSign,
+      path: '/led-sign',
       allowedIf: userIsOfficerOrAdmin,
       redirect: '/'
     },

--- a/test/LedSign.js
+++ b/test/LedSign.js
@@ -1,0 +1,107 @@
+/* global describe it before after afterEach */
+// During the test the env variable is set to test
+process.env.NODE_ENV = 'test'
+// Require the dev-dependencies
+const chai = require('chai')
+const chaiHttp = require('chai-http')
+const constants = require('../api/constants')
+const { OK, BAD_REQUEST, NOT_FOUND } = constants.STATUS_CODES
+const tools = require('../util/testing-utils/tools.js')
+const LedSignFunctions = require('../printingRPC/client/ledsign/led_sign_client')
+const sinon = require('sinon')
+
+let app = null
+const expect = chai.expect
+
+chai.should()
+chai.use(chaiHttp)
+const SUCCESS_MESSAGE = 'success'
+const ERROR_MESSAGE = 'error'
+const TEXT_REQUEST = {
+  text: 'Hi thai',
+  brightness: 50,
+  scrollSpeed: 50,
+  backgroundColor: '#00FF00',
+  textColor: '#FF0000',
+  borderColor: '#0000FF'
+}
+
+describe('LedSign', () => {
+  const healthCheckMock = sinon.stub(LedSignFunctions, 'healthCheck')
+  const updateSignTextMock = sinon.stub(LedSignFunctions, 'updateSignText')
+
+  before(done => {
+    app = tools.initializeServer()
+    done()
+  })
+
+  after(done => {
+    healthCheckMock.restore()
+    updateSignTextMock.restore()
+    tools.terminateServer(done)
+  })
+
+  afterEach(() => {
+    healthCheckMock.reset()
+    updateSignTextMock.reset()
+  })
+
+  describe('/POST healthCheck', () => {
+    it('Should return statusCode 200 when the sign is up', done => {
+      healthCheckMock.resolves(SUCCESS_MESSAGE)
+      chai
+        .request(app)
+        .post('/api/LedSign/healthCheck')
+        .then(function (res) {
+          expect(res).to.have.status(OK)
+          done()
+        })
+        .catch(err => {
+          throw err
+        })
+    })
+    it('Should return statusCode 404 when the sign is down', done => {
+      healthCheckMock.rejects(ERROR_MESSAGE)
+      chai
+        .request(app)
+        .post('/api/LedSign/healthCheck')
+        .then(function (res) {
+          expect(res).to.have.status(NOT_FOUND)
+          done()
+        })
+        .catch(err => {
+          throw err
+        })
+    })
+  })
+
+  describe('/POST updateSignText', () => {
+    it('Should return statusCode 200 when the sign text is updated', done => {
+      updateSignTextMock.resolves(SUCCESS_MESSAGE)
+      chai
+        .request(app)
+        .post('/api/LedSign/updateSignText')
+        .send(TEXT_REQUEST)
+        .then(function (res) {
+          expect(res).to.have.status(OK)
+          done()
+        })
+        .catch(err => {
+          throw err
+        })
+    })
+    it('Should return statusCode 400 when the sign is down', done => {
+      updateSignTextMock.rejects(ERROR_MESSAGE)
+      chai
+        .request(app)
+        .post('/api/LedSign/updateSignText')
+        .then(function (res) {
+          expect(res).to.have.status(BAD_REQUEST)
+          done()
+        })
+        .catch(err => {
+          throw err
+        })
+    })
+  })
+})

--- a/test/TokenFunctions.js
+++ b/test/TokenFunctions.js
@@ -1,4 +1,4 @@
-/* global describe it before after */
+/* global describe it before after afterEach */
 const sinon = require('sinon')
 const chai = require('chai')
 const expect = chai.expect

--- a/test/frontend/AdminNavbar.test.js
+++ b/test/frontend/AdminNavbar.test.js
@@ -25,12 +25,12 @@ describe('<AdminNavbar />', () => {
         .toString() === 'Software & Computer Engineering Society'
     )
   })
-  it('Should render 5 <NavLink /> tags with officer Credentials', () => {
+  it('Should render 4 <NavLink /> tags with officer Credentials', () => {
     const wrapper = mount(<AdminNavbar />)
-    expect(wrapper.find(NavLink)).to.have.lengthOf(3)
+    expect(wrapper.find(NavLink)).to.have.lengthOf(4)
   })
-  it('Should render 6 <NavLink /> tags with admin Credentials', () => {
+  it('Should render 4 <NavLink /> tags with admin Credentials', () => {
     const wrapper = mount(<AdminNavbar {...adminAppProps} />)
-    expect(wrapper.find(NavLink)).to.have.lengthOf(3)
+    expect(wrapper.find(NavLink)).to.have.lengthOf(4)
   })
 })

--- a/test/frontend/LedSign.test.js
+++ b/test/frontend/LedSign.test.js
@@ -1,0 +1,77 @@
+/* global describe it before after */
+import 'jsdom-global/register'
+import React from 'react'
+import Enzyme, { mount } from 'enzyme'
+import { expect } from 'chai'
+import * as LedSignAPI from '../../src/APIFunctions/LedSign'
+import sinon from 'sinon'
+
+import LedSign from '../../src/Pages/LedSign/LedSign'
+import Adapter from 'enzyme-adapter-react-16'
+import { Input, Spinner } from 'reactstrap'
+
+Enzyme.configure({ adapter: new Adapter() })
+
+describe('<LedSign />', () => {
+  var stub = null
+  before(done => {
+    stub = sinon.stub(LedSignAPI, 'healthCheck')
+    done()
+  })
+
+  after(done => {
+    if (stub) stub.restore()
+    done()
+  })
+
+  function healthCheckWillReturn (value) {
+    if (stub) stub.returns(Promise.resolve(value))
+  }
+
+  const appProps = {
+    user: { name: 'test' }
+  }
+  const signHealthy = { error: false }
+  const signUnhealthy = { error: true }
+
+  it('Should render six <Input /> components', () => {
+    const wrapper = mount(<LedSign {...appProps} />)
+    expect(wrapper.find(Input)).to.have.lengthOf(6)
+  })
+  it('Should render a loading animation when waiting for a sign response', () => {
+    const wrapper = mount(<LedSign {...appProps} />)
+    console.log(wrapper.find('.sign-status').text())
+    expect(wrapper.find(Spinner)).to.have.lengthOf(1)
+  })
+  it('Should alert the user if the sign is down', async () => {
+    healthCheckWillReturn(signUnhealthy)
+    const wrapper = await mount(<LedSign {...appProps} />)
+    expect(wrapper.find('.sign-status').text()).to.equal(
+      'Sign Status: Sign is down!'
+    )
+  })
+  it('Should disable all <Input /> components when sign is down', () => {
+    const wrapper = mount(<LedSign {...appProps} />)
+    const inputArray = wrapper.find(Input)
+    inputArray.map(element => {
+      expect(element.props().disabled).to.equal(true)
+    })
+  })
+  it('Should display if the sign is up', async () => {
+    healthCheckWillReturn(signHealthy)
+    const wrapper = await mount(<LedSign {...appProps} />)
+    expect(wrapper.find('.sign-status').text()).to.equal(
+      'Sign Status: Sign is up.'
+    )
+  })
+  it('Should enable all <Input /> components when sign is up', async () => {
+    healthCheckWillReturn(signHealthy)
+    const wrapper = await mount(<LedSign {...appProps} />)
+    await Promise.all([healthCheckWillReturn])
+    wrapper.update()
+    const inputArray = wrapper.find(Input)
+    inputArray.map(element => {
+      expect(element.props().disabled).to.be.equal(false)
+    })
+  })
+})


### PR DESCRIPTION
Now, we can control the sign from anywhere using @jerrylee17's RPC repository.

### Sign Page in NavBar
![image](https://user-images.githubusercontent.com/36345325/74003699-67f74800-4928-11ea-8b32-462201d9ba2a.png)

### The Sign Page
![image](https://user-images.githubusercontent.com/36345325/74003690-5f067680-4928-11ea-9867-eac1e0a93f99.png)

### Sign Page Shows Sign Status
The inputs are also disabled
![image](https://user-images.githubusercontent.com/36345325/74003792-b4428800-4928-11ea-8fd7-8c0588aeeb15.png)
### Awaiting Sign Status Check
![image](https://user-images.githubusercontent.com/36345325/74003826-cd4b3900-4928-11ea-8259-e40a811ab8c9.png)

### Shows If Request Successfully Sent
![image](https://user-images.githubusercontent.com/36345325/74004080-99bcde80-4929-11ea-9560-6d5172eb3b99.png)

### Shows if Request Failed
![image](https://user-images.githubusercontent.com/36345325/74004349-675fb100-492a-11ea-93a5-a1e21b653dc0.png)


Resolves #227 