### PR TITLE
Fixed Print Count Endpoint

### DIFF
--- a/api/routes/user.js
+++ b/api/routes/user.js
@@ -325,7 +325,7 @@ router.post('/setEmailToVerified', (req, res) => {
   })
 })
 
-router.post('getPagesPrintedCount', (req, res) => {
+router.post('/getPagesPrintedCount', (req, res) => {
   if (!checkIfTokenSent(req)) {
     return res.sendStatus(FORBIDDEN)
   } else if (!checkIfTokenValid(req)) {


### PR DESCRIPTION
All API endpoints must have a slash in front to work properly.