### PR TITLE
Save User's Emails as Lowercase

### DIFF
--- a/api/routes/user.js
+++ b/api/routes/user.js
@@ -60,7 +60,7 @@ router.post('/register', function(req, res) {
       firstName: req.body.firstName,
       middleInitial: req.body.middleInitial || '',
       lastName: req.body.lastName,
-      email: req.body.email,
+      email: req.body.email.toLowerCase(),
       major: req.body.major || ''
     });
 


### PR DESCRIPTION
Resolves registered user's emails not being found if they used some sort of capitalization.