### PR TITLE
Prevent Server from Crashing due to no Token File

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,7 +44,7 @@
             "error",
             {
                 "allow": [
-                    "error"
+                    "debug"
                 ]
             }
         ],

--- a/api/mailer/mailer.js
+++ b/api/mailer/mailer.js
@@ -41,7 +41,7 @@ function getNewToken(oAuth2Client) {
     // prompt: 'consent',
     scope: SCOPES
   });
-  // console.log('Authorize this app by visiting this url:', authUrl);
+  console.debug('Authorize this app by visiting this url:', authUrl);
 
   const rl = readline.createInterface({
     input: process.stdin,
@@ -52,12 +52,12 @@ function getNewToken(oAuth2Client) {
     rl.close();
 
     oAuth2Client.getToken(code, (err, token) => {
-      if (err) return console.error('Error retrieving access token', err);
+      if (err) return console.debug('Error retrieving access token', err);
       oAuth2Client.setCredentials(token);
       // Store the token to disk for later program executions
       fs.writeFile(TOKEN_PATH, JSON.stringify(token), err => {
-        if (err) return console.error('ERR', err);
-        // console.log('Token stored to', TOKEN_PATH);
+        if (err) return console.debug('ERR', err);
+        console.debug('Token stored to', TOKEN_PATH);
       });
     });
   });
@@ -90,50 +90,56 @@ function refreshAccessToken() {
 
   oAuth2Client.getAccessToken().then(token => {
     fs.writeFile(TOKEN_PATH, JSON.stringify(token.res.data), err => {
-      if (err) return console.error(err);
+      if (err) return console.debug(err);
     });
   });
 }
 
+function sendVerificationEmail(mailTemplate, token) {
+  const smtpTransport = nodemailer.createTransport({
+    service: 'gmail',
+    auth: {
+      type: 'OAuth2',
+      user: USER,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+      accessToken: token.access_token
+    }
+  });
+
+  if (process.env.NODE_ENV === 'production') {
+    smtpTransport.sendMail(mailTemplate, (error, response) => {
+      error ? reject(error) : resolve(response);
+      smtpTransport.close();
+    });
+  } else {
+    // console.log('DEV - Mail:');
+    // console.log(mailTemplate);
+    resolve();
+  }
+}
+
 const send = ({ templateType, recipientEmail, recipientName }) => {
-  return new Promise((resolve, reject) => {
-    getMailTemplate(templateType, recipientEmail, recipientName).then(
-      mailTemplate => {
-        function callback(token) {
-          const smtpTransport = nodemailer.createTransport({
-            service: 'gmail',
-            auth: {
-              type: 'OAuth2',
-              user: USER,
-              clientId: CLIENT_ID,
-              clientSecret: CLIENT_SECRET,
-              accessToken: token.access_token
+  return new Promise(async(resolve, reject) => {
+    getMailTemplate(templateType, recipientEmail, recipientName)
+      .then(
+        async mailTemplate => {
+          fs.readFile(TOKEN_PATH, async(err, token) => {
+            if (err) {
+              reject(err);
+            }
+            // This needs a .then or async statement so 
+            // it doesnt move until a new access token is created
+            if (checkIfTokenIsExpired(JSON.parse(token))) {
+              await refreshAccessToken();
+              sendVerificationEmail(mailTemplate, JSON.parse(token));
+            } else {
+              sendVerificationEmail(mailTemplate, JSON.parse(token));
             }
           });
-
-          if (process.env.NODE_ENV === 'production') {
-            smtpTransport.sendMail(mailTemplate, (error, response) => {
-              error ? reject(error) : resolve(response);
-              smtpTransport.close();
-            });
-          } else {
-            // console.log('DEV - Mail:');
-            // console.log(mailTemplate);
-            resolve();
-          }
         }
-
-        fs.readFile(TOKEN_PATH, (err, token) => {
-          if (err) reject(err);
-
-          // This needs a .then or async statement so 
-          // it doesnt move until a new access token is created
-          if (checkIfTokenIsExpired(JSON.parse(token))) refreshAccessToken();
-          else callback(JSON.parse(token));
-        });
-      }
-    );
-  }).catch(error => reject(error));
+      );
+  }).catch(error => console.debug(error));
 };
 
 module.exports = {

--- a/src/Pages/MembershipApplication/VerifyEmail.js
+++ b/src/Pages/MembershipApplication/VerifyEmail.js
@@ -58,7 +58,7 @@ export default class VerifyEmail extends React.Component {
         }
       })
       .catch(error => {
-        console.error(error);
+        console.debug(error);
       });
   }
 


### PR DESCRIPTION
Before, when we would try to send a verification email with no token.js file
present, the server would just crash and we would have to manually restart
it. Now we have some resilience in that we just move on if there is no
token file.