### PR TITLE
Allow Space for Async Arrow Function

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -56,10 +56,11 @@
         ],
         "no-extra-semi": "error",
         "eol-last": 2,
-        "space-before-function-paren": [
-            2,
-            "never"
-        ],
+        "space-before-function-paren": ["error", {
+          "anonymous": "never",
+          "named": "never",
+          "asyncArrow": "always"
+        }],
         "no-warning-comments": [
             2,
             {

--- a/api/mailer/mailer.js
+++ b/api/mailer/mailer.js
@@ -120,11 +120,11 @@ function sendVerificationEmail(mailTemplate, token) {
 }
 
 const send = ({ templateType, recipientEmail, recipientName }) => {
-  return new Promise(async(resolve, reject) => {
+  return new Promise(async (resolve, reject) => {
     getMailTemplate(templateType, recipientEmail, recipientName)
       .then(
         async mailTemplate => {
-          fs.readFile(TOKEN_PATH, async(err, token) => {
+          fs.readFile(TOKEN_PATH, async (err, token) => {
             if (err) {
               reject(err);
             }

--- a/api/routes/LedSign.js
+++ b/api/routes/LedSign.js
@@ -8,7 +8,7 @@ const { OK, NOT_FOUND, BAD_REQUEST } = require('../constants').STATUS_CODES;
 const { ledSignIp } = require('../config/config');
 const SignLog = require('../models/SignLog');
 
-router.post('/updateSignText', async(req, res) => {
+router.post('/updateSignText', async (req, res) => {
   const newSign = new SignLog({
     signTitle: req.body.text,
     firstName: req.body.firstName,
@@ -29,7 +29,7 @@ router.post('/updateSignText', async(req, res) => {
     });
 });
 
-router.post('/healthCheck', async(req, res) => {
+router.post('/healthCheck', async (req, res) => {
   const { officerName } = req.body;
   await healthCheck(officerName, ledSignIp)
     .then(response => {

--- a/api/routes/print.js
+++ b/api/routes/print.js
@@ -7,7 +7,7 @@ const {
 } = require('../printingRPC/client/printing/print_client');
 const { OK, BAD_REQUEST } = require('../constants').STATUS_CODES;
 
-router.post('/submit', async(req, res) => {
+router.post('/submit', async (req, res) => {
   const { raw, pageRanges, sides, copies, destination } = req.body;
   await sendPrintRequest(raw, copies, sides, pageRanges, destination)
     .then(response => {

--- a/src/Pages/2DPrinting/2DPrinting.js
+++ b/src/Pages/2DPrinting/2DPrinting.js
@@ -152,7 +152,7 @@ export default function Printing(props) {
             const tmp = fileItems.map(fileItem => fileItem.file);
             setFiles(tmp);
           }}
-          onaddfile={async(err, file) => {
+          onaddfile={async (err, file) => {
             if (!err) await handleUpdate(file);
           }}
           onremovefile={err => {

--- a/src/Pages/3DPrintingConsole/3DConsole.js
+++ b/src/Pages/3DPrintingConsole/3DConsole.js
@@ -66,7 +66,7 @@ export default class PrintConsole3D extends React.Component {
   Search for object in db using its name and date
   Set new progress = event value
   */
-  handleUpdateProgress = async(requestToUpdate, event) => {
+  handleUpdateProgress = async (requestToUpdate, event) => {
     const newProgress = event.target.value;
     if (newProgress === requestToUpdate.progress) return;
     const updateRequest = {

--- a/src/Pages/Profile/MemberView/PrintRequest.js
+++ b/src/Pages/Profile/MemberView/PrintRequest.js
@@ -16,7 +16,7 @@ export default function PrintRequest(props) {
 
   return (
     <Button
-      onClick={async() => {
+      onClick={async () => {
         await updateRequests();
         setToggle(!toggle);
       }}

--- a/test/frontend/EventList.test.js
+++ b/test/frontend/EventList.test.js
@@ -48,7 +48,7 @@ describe('<EventList />', () => {
   it(
     'Should render an <EventCard /> component for every element in the event' +
       ' array',
-    async() => {
+    async () => {
       returnEventArray();
       const wrapper = await mount(<EventList />);
       wrapper.update();
@@ -57,7 +57,7 @@ describe('<EventList />', () => {
       );
     }
   );
-  it('Should render a title if no events are returned', async() => {
+  it('Should render a title if no events are returned', async () => {
     returnEmptyArray();
     const wrapper = await mount(<EventList />);
     wrapper.update();
@@ -69,7 +69,7 @@ describe('<EventList />', () => {
         .get(0).props.children[1].props.children
     ).to.equal('No events yet!');
   });
-  it('Should initially hide an <EventInfoModal /> component', async() => {
+  it('Should initially hide an <EventInfoModal /> component', async () => {
     returnEventArray();
     const wrapper = await mount(<EventList />);
     wrapper.update();

--- a/test/frontend/EventManager.test.js
+++ b/test/frontend/EventManager.test.js
@@ -52,7 +52,7 @@ describe('<EventManager />', () => {
   it(
     'Should render an <EventCard /> component for every element in the event' +
       ' array',
-    async() => {
+    async () => {
       returnEventArray();
       const wrapper = await mount(<EventManager {...APP_PROPS} />);
       wrapper.update();
@@ -61,7 +61,7 @@ describe('<EventManager />', () => {
       );
     }
   );
-  it('Should render a title if no events are returned', async() => {
+  it('Should render a title if no events are returned', async () => {
     returnEmptyArray();
     const wrapper = await mount(<EventManager {...APP_PROPS} />);
     wrapper.update();
@@ -70,7 +70,7 @@ describe('<EventManager />', () => {
       'No events yet!'
     );
   });
-  it('Should initially hide an <EventManagerModal /> component', async() => {
+  it('Should initially hide an <EventManagerModal /> component', async () => {
     returnEventArray();
     const wrapper = await mount(<EventList />);
     wrapper.update();

--- a/test/frontend/LedSign.test.js
+++ b/test/frontend/LedSign.test.js
@@ -43,7 +43,7 @@ describe('<LedSign />', () => {
     const wrapper = mount(<LedSign {...appProps} />);
     expect(wrapper.find(Spinner)).to.have.lengthOf(1);
   });
-  it('Should alert the user if the sign is down', async() => {
+  it('Should alert the user if the sign is down', async () => {
     healthCheckWillReturn(signUnhealthy);
     const wrapper = await mount(<LedSign {...appProps} />);
     expect(wrapper.find('.sign-status').text()).to.equal(
@@ -57,14 +57,14 @@ describe('<LedSign />', () => {
       expect(element.props().disabled).to.equal(true);
     });
   });
-  it('Should display if the sign is up', async() => {
+  it('Should display if the sign is up', async () => {
     healthCheckWillReturn(signHealthy);
     const wrapper = await mount(<LedSign {...appProps} />);
     expect(wrapper.find('.sign-status').text()).to.equal(
       'Sign Status: Sign is up.'
     );
   });
-  it('Should enable all <Input /> components when sign is up', async() => {
+  it('Should enable all <Input /> components when sign is up', async () => {
     healthCheckWillReturn(signHealthy);
     const wrapper = await mount(<LedSign {...appProps} />);
     await Promise.all([healthCheckWillReturn]);


### PR DESCRIPTION
It makes sense to allow a space between the async keyword and parenthesis.