### PR TITLE
Create application that handles dev account creation

### DIFF
--- a/api/models/User.js
+++ b/api/models/User.js
@@ -66,6 +66,12 @@ const UserSchema = new Schema(
 
 UserSchema.pre('save', function(next) {
   const member = this;
+  let emailRegExp = new RegExp (['^[a-zA-Z0-9.!#$%&\'*+\/=?^_`{|}~-]+@[a-zA-Z0',
+    '-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61',
+    '}[a-zA-Z0-9])?)*$'].join(''));
+  if (!this.email.match(emailRegExp)) {
+    return next('Bad email tried to be save (email format is: example@domain)');
+  }
   if (this.isModified('password') || this.isNew) {
     bcrypt.genSalt(10, function(error, salt) {
       if (error) {

--- a/api/package.json
+++ b/api/package.json
@@ -5,7 +5,8 @@
   "main": "SceHttpServer.js",
   "scripts": {
     "start": "node SceHttpServer.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "create-user": "node ./util/CreateUserScript.js"
   },
   "repository": {
     "type": "git",

--- a/api/util/CreateUserScript.js
+++ b/api/util/CreateUserScript.js
@@ -1,0 +1,120 @@
+'use strict';
+const User = require('../models/User.js');
+const inquirer = require('inquirer');
+const mongoose = require('mongoose');
+mongoose.Promise = require('bluebird');
+let membershipState = require('../../src/Enums.js');
+membershipState = membershipState.membershipState;
+
+const redColor = '\x1b[31m';
+const greenColor = '\x1b[32m';
+const blueColor = '\x1b[34m';
+const defaultColor = '\x1b[0m';
+
+console.debug(blueColor, 'Welcome to the SCE User Creation CLI!', defaultColor);
+inquirer
+  .prompt([
+    {
+      type: 'input',
+      name: 'email',
+      message: 'What\'s your email:'
+    },
+    {
+      type: 'input',
+      name: 'firstName',
+      message: 'Please enter a first name for your account (default: "Dummy"):'
+    },
+    {
+      type: 'input',
+      name: 'lastName',
+      message: 'Please enter a last name for your account (defualt: "Account"):'
+    },
+    {
+      type: 'input',
+      name: 'password',
+      message: 'Please enter a password (default: "sce"):'
+    },
+    {
+      type: 'list',
+      name: 'accountLevel',
+      message: 'Choose an account level from the list below: ',
+      choices: [
+        {
+          name: 'Admin',
+          value: membershipState.ADMIN
+        },
+        {
+          name: 'Officer',
+          value: membershipState.OFFICER
+        },
+        {
+          name: 'Member',
+          value: membershipState.MEMBER
+        },
+        {
+          name: 'Non-Member',
+          value: membershipState.NON_MEMBER
+        },
+        {
+          name: 'Pending',
+          value: membershipState.PENDING
+        },
+        {
+          name: 'Banned',
+          value: membershipState.BANNED
+        }
+      ],
+      filter: function(val) {
+        console.debug(val);
+        return val;
+      }
+    }
+  ])
+  .then(async (answers) => {
+    const newUser = new User({
+      password: answers.password || 'sce',
+      firstName: answers.firstName || 'Dummy',
+      lastName: answers.lastName || 'Account',
+      email: answers.email,
+      emailVerified: true,
+      accessLevel: answers.accountLevel
+    });
+    this.mongoose = mongoose;
+    this.mongoose
+      .connect('mongodb://localhost/sce_core', {
+        promiseLibrary: require('bluebird'),
+        useNewUrlParser: true,
+        serverSelectionTimeoutMS: 3000,
+        useUnifiedTopology: true,
+        useCreateIndex: true
+      })
+      .catch(_ => {
+        console.debug(redColor, 'MongoDB Connection Unsuccessful. Are you sure'
+                     + ' MongoDB is running?', defaultColor);
+        process.exit();
+      });
+    await newUser.save()
+      .then(_ => {
+        console.debug(greenColor, 'Account with email ' + answers.email
+                    + ' and password '
+                    + ((answers.password) ? answers.password : 'sce')
+                    + ' succesfully created.', defaultColor);
+        this.mongoose.connection.close();
+      })
+      .catch(_=> {
+        console.debug(redColor, 'Account creation unsuccessful. Please try'
+                                + ' running the user creation script'
+                                + ' again.', defaultColor);
+        this.mongoose.connection.close();
+        process.exit();
+      });
+  })
+  .catch(error => {
+    if(error.isTTyError) {
+      console.debug(redColor, error, 'prompt couldn\'t be rendered in tty'
+                    + 'environment.', defaultColor);
+    } else {
+      console.debug(redColor, error, 'error processing response.',
+        defaultColor);
+    }
+  });

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "frontend": "react-scripts start",
     "build": "react-scripts build",
     "deploy": "git pull && npm install && pm2 stop database api app && pm2 delete database api app && pm2 start mongod --name \"database\" && npm run build && pm2 start npm --name \"app\" -- start && pm2 start npm \"app\" -- run dev",
-    "lint": "./node_modules/.bin/eslint src/ api/models/ api/mailer/ api/routes/ api/util util/ test/"
+    "lint": "./node_modules/.bin/eslint src/ api/models/ api/mailer/ api/routes/ api/util util/ test/",
+    "create-user": "npm run create-user --prefix api"
   },
   "keywords": [
     "sce_core",


### PR DESCRIPTION
Resolves #422

How to test this PR out:
1. Clone / checkout the `create-user` branch
2. Run `npm install` in the terminal
3. Start mongodb
4. Run the creation script with the command `npm run create-user`. You can try variations with this like running the server/frontend and also running this script at the same time.
5. Run the server/frontend (if you haven't already) to test the account you just created

~~Everytime you run the script you have to discard the terminal afterwards.~~ You no longer have to discard the terminal everytime you run the script.

Bad email example(s):
![image](https://user-images.githubusercontent.com/36381158/83805270-6df5ff00-a664-11ea-9241-64b09484ff72.png)

![image](https://user-images.githubusercontent.com/36381158/83805336-882fdd00-a664-11ea-8777-898c86a37092.png)

No password & password provided sample executions:
![image](https://user-images.githubusercontent.com/36381158/83805978-a3e7b300-a665-11ea-9ecc-832c5932871a.png)

![image](https://user-images.githubusercontent.com/36381158/83806006-ab0ec100-a665-11ea-88b5-54df6a703b06.png)

