### PR TITLE
Change getItems from post to get request

### DIFF
--- a/api/routes/InventoryItem.js
+++ b/api/routes/InventoryItem.js
@@ -16,7 +16,7 @@ const {
 } = require('../constants').STATUS_CODES;
 const addErrorLog = require('../util/errorLog');
 
-router.post('/getItems', (req, res) => {
+router.get('/getItems', (req, res) => {
   const category = req.body.category ? { category: req.body.category } : {};
   InventoryItem.find(category).then(items => res.status(OK).send(items));
 });

--- a/test/InventoryItem.js
+++ b/test/InventoryItem.js
@@ -124,7 +124,7 @@ describe('InventoryItem', () => {
       setTokenStatus(true);
       chai
         .request(app)
-        .post('/api/InventoryItem/getItems')
+        .get('/api/InventoryItem/getItems')
         .then(function(res) {
           expect(res).to.have.status(OK);
           const getItemsResponse = res.body;
@@ -194,7 +194,7 @@ describe('InventoryItem', () => {
       setTokenStatus(true);
       chai
         .request(app)
-        .post('/api/InventoryItem/getItems')
+        .get('/api/InventoryItem/getItems')
         .then(function(res) {
           expect(res).to.have.status(OK);
           const getItemsResponse = res.body;
@@ -262,7 +262,7 @@ describe('InventoryItem', () => {
       setTokenStatus(true);
       chai
         .request(app)
-        .post('/api/InventoryItem/getItems')
+        .get('/api/InventoryItem/getItems')
         .then(function(res) {
           expect(res).to.have.status(OK);
           const getItemsResponse = res.body;


### PR DESCRIPTION
Made a small change. Instead of using a post request in the getItems Inventory routing, I used a get request. This change was made so that it could stay consistent with all the other routing calls. 