### PR TITLE
Added confirmation modal 3D Printing console

### DIFF
--- a/src/Pages/3DPrintingConsole/3D-console.css
+++ b/src/Pages/3DPrintingConsole/3D-console.css
@@ -1,31 +1,13 @@
-.App {
-  text-align: center;
-}
-
-.App-logo {
-  animation: App-logo-spin infinite 20s linear;
-  height: 40vmin;
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
 .request-card {
-  background-color: #333;
+  background-color: #333 !important;
+  margin-bottom: 0 !important;
 }
 .request-label-2 {
   display: none;
+}
+
+.request-info{
+  margin-top: 0 !important;
 }
 
 @media only screen and (max-width: 1090px) {

--- a/src/Pages/3DPrintingConsole/3DConsole.js
+++ b/src/Pages/3DPrintingConsole/3DConsole.js
@@ -9,6 +9,8 @@ import {
   update3DPrintRequestProgress
 } from '../../APIFunctions/3DPrinting';
 import Header from '../../Components/Header/Header';
+import ConfirmationModal from
+  '../../Components/DecisionModal/ConfirmationModal';
 
 export default class PrintConsole3D extends React.Component {
   constructor(props) {
@@ -18,7 +20,9 @@ export default class PrintConsole3D extends React.Component {
       collapse: true,
       data: [],
       key: '',
-      search: ''
+      search: '',
+      modalOpen: false,
+      itemToDelete: null
     };
     this.headerProps = {
       title: '3D Console'
@@ -46,12 +50,23 @@ export default class PrintConsole3D extends React.Component {
     }
   }
 
-  /*
-  Delete api
-  parameter: Json object of object to be deleted
-  Search for object in db using name and color then delete
-  */
-  handleDeleteData = async requestToDelete => {
+  handleConfirmationModal = async item => {
+    this.setState({
+      modalOpen: true,
+      itemToDelete: item
+    });
+  }
+
+  toggleModal = () => {
+    this.setState({
+      modalOpen: !this.state.modalOpen
+    });
+  }
+
+  delete3dPrintRequest = async requestToDelete => {
+    this.setState({
+      modalOpen: false
+    });
     const deleteResponse = await delete3DPrintRequest(
       requestToDelete,
       this.state.authToken
@@ -124,10 +139,18 @@ export default class PrintConsole3D extends React.Component {
                 key={key}
                 handleToggle={this.handleToggle}
                 handleUpdateProgress={this.handleUpdateProgress}
-                handleDeleteData={this.handleDeleteData}
+                handleDelete={this.handleConfirmationModal}
                 collapse={this.state.collapse}
               />
             ))}
+            <ConfirmationModal
+              headerText = 'Delete 3D Print Request'
+              bodyText = {'Are you sure you want to ' +
+                'delete this print request?'}
+              handleConfirmation = {() =>
+                this.delete3dPrintRequest(this.state.itemToDelete)}
+              open = {this.state.modalOpen}
+              toggle = {this.toggleModal}/>
           </Form>
         </Container>
       </div>

--- a/src/Pages/3DPrintingConsole/RequestForm.js
+++ b/src/Pages/3DPrintingConsole/RequestForm.js
@@ -54,7 +54,7 @@ function RequestForm(props) {
       color: 'danger',
       value: 'Delete',
       handleUpdates: e => {
-        props.handleDeleteData(item);
+        props.handleDelete(item);
       }
     }
   ];
@@ -110,7 +110,7 @@ function RequestForm(props) {
       </Card>
 
       <Collapse isOpen={props.collapse}>
-        <Card>
+        <Card className = 'request-info'>
           <CardBody>
             <Row>
               {printColumnInfo.map((columnInfo, index) => {


### PR DESCRIPTION
Resolves #373 

-Used confirmation modal so that if an admin clicks on the delete button in the 3D Printing console, it will prompt a confirmation modal before deleting. 

-Fixed some styling issues

