### PR TITLE
Fixes Discord Auth Links

### DIFF
--- a/api/cloud_api/email_templates/verification.js
+++ b/api/cloud_api/email_templates/verification.js
@@ -4,7 +4,8 @@ function verification(user, recipient, name) {
   return new Promise((resolve, reject) => {
     generateHashedId(recipient)
       .then(hashedId => {
-        const url = process.env.NODE_ENV === 'production' ? 'https://sce.engr.sjsu.edu' : 'http://localhost:3000'
+        // eslint-disable-next-line
+        const url = process.env.NODE_ENV === 'production' ? 'https://sce.engr.sjsu.edu' : 'http://localhost:3000';
         const verifyLink =
           `${url}/verify?id=${hashedId}&user=${recipient}`;
         return resolve({

--- a/api/config/config.example.json
+++ b/api/config/config.example.json
@@ -1,37 +1,37 @@
 {
-    "CLOUD_API_URL": "http://localhost:8082/cloudapi",
-    "discordApiKeys": {
-        "CLIENT_ID": "XXXXXXXXXXXXXXXXXX",
-        "CLIENT_SECRET": "XXXXXXXXXXXXXXXXXX",
-        "REDIRECT_URI_DEV": "http%3A%2F%2Flocalhost%3A8080%2Fapi%2Fuser%2Fcallback&response_type=code&scope=identify",
-        "REDIRECT_URI_PROD": "http%3A%2F%2Fsce.engr.sjsu.edu%2Fprofile&response_type=code&scope=identify",
-        "REFRESH_TOKEN": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-    },
-    "GENERAL_API_URL": "http://localhost:8080/api",
-    "githubApiKeys": {
-        "CLIENT_ID": "XXXXXXXXXXXXXXXXXXXX",
-        "CLIENT_SECRET": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-    },
-    "googleApiKeys": {
-        "CLIENT_ID": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-        "CLIENT_SECRET": "XXXXXXXXXXXXXXXXXXXX",
-        "REDIRECT_URIS": [
-            "https://developers.google.com/oauthplayground"
-        ],
-        "REFRESH_TOKEN": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-        "USER": "sce.sjsu@gmail.com"
-    },
-    "googleCalendarIds": {
-        "PRIMARY_CAL": "primary",
-        "SCE_EVENTS_CAL": "XXXXXXXXXXXXXXXXXXXXXXXXXXX"
-    },
-    "ledSignIp": "192.168.4.1",
-    "LOGGING_API_URL": "http://localhost:8081/loggingapi",
-    "passwordStrength": "medium",
-    "S3Bucket": {
-        "AWSACCESSKEYID": "XXXXXXXXXXXXXXXXXXXX",
-        "AWSSECRETKEY": "XXXXXXXXXXXXXXXXXXXXXXXX",
-        "BUCKET": "XXXXXXXXXXXXX"
-    },
-    "secretKey": "super duper secret key"
+  "CLOUD_API_URL": "http://localhost:8082/cloudapi",
+  "discordApiKeys": {
+    "CLIENT_ID": "XXXXXXXXXXXXXXXXXX",
+    "CLIENT_SECRET": "XXXXXXXXXXXXXXXXXX",
+    "REDIRECT_URI_DEV": "http%3A%2F%2Flocalhost%3A8080%2Fapi%2Fuser%2Fcallback&response_type=code&scope=identify",
+    "REDIRECT_URI_PROD": "http%3A%2F%2Fsce.engr.sjsu.edu%2Fprofile&response_type=code&scope=identify",
+    "REFRESH_TOKEN": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+  },
+  "GENERAL_API_URL": "http://localhost:8080/api",
+  "githubApiKeys": {
+    "CLIENT_ID": "XXXXXXXXXXXXXXXXXXXX",
+    "CLIENT_SECRET": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+  },
+  "googleApiKeys": {
+    "CLIENT_ID": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    "CLIENT_SECRET": "XXXXXXXXXXXXXXXXXXXX",
+    "REDIRECT_URIS": [
+      "https://developers.google.com/oauthplayground"
+    ],
+    "REFRESH_TOKEN": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    "USER": "sce.sjsu@gmail.com"
+  },
+  "googleCalendarIds": {
+    "PRIMARY_CAL": "primary",
+    "SCE_EVENTS_CAL": "XXXXXXXXXXXXXXXXXXXXXXXXXXX"
+  },
+  "ledSignIp": "192.168.4.1",
+  "LOGGING_API_URL": "http://localhost:8081/loggingapi",
+  "passwordStrength": "medium",
+  "S3Bucket": {
+    "AWSACCESSKEYID": "XXXXXXXXXXXXXXXXXXXX",
+    "AWSSECRETKEY": "XXXXXXXXXXXXXXXXXXXXXXXX",
+    "BUCKET": "XXXXXXXXXXXXX"
+  },
+  "secretKey": "super duper secret key"
 }

--- a/api/config/config.example.json
+++ b/api/config/config.example.json
@@ -1,37 +1,37 @@
 {
-  "CLOUD_API_URL": "http://localhost:8082/cloudapi",
-  "discordApiKeys": {
-      "CLIENT_ID": "XXXXXXXXXXXXXXXXXX",
-      "CLIENT_SECRET": "XXXXXXXXXXXXXXXXXX",
-      "REDIRECT_URI_DEV": "http%3A%2F%2Flocalhost%3A8080%2Fapi%2Fuser%2Fcallback&response_type=code&scope=identify",
-      "REDIRECT_URI_PROD": "http%3A%2F%2Fsce.sjsu.edu%2Fapi%2Fuser%2Fcallback&response_type=code&scope=identify",
-      "REFRESH_TOKEN": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-  },
-  "GENERAL_API_URL": "http://localhost:8080/api",
-  "githubApiKeys": {
-      "CLIENT_ID": "XXXXXXXXXXXXXXXXXXXX",
-      "CLIENT_SECRET": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-  },
-  "googleApiKeys": {
-      "CLIENT_ID": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-      "CLIENT_SECRET": "XXXXXXXXXXXXXXXXXXXX",
-      "REDIRECT_URIS": [
-          "https://developers.google.com/oauthplayground"
-      ],
-      "REFRESH_TOKEN": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-      "USER": "sce.sjsu@gmail.com"
-  },
-  "googleCalendarIds": {
-      "PRIMARY_CAL": "primary",
-      "SCE_EVENTS_CAL": "XXXXXXXXXXXXXXXXXXXXXXXXXXX"
-  },
-  "ledSignIp": "192.168.4.1",
-  "LOGGING_API_URL": "http://localhost:8081/loggingapi",
-  "passwordStrength": "medium",
-  "S3Bucket": {
-      "AWSACCESSKEYID": "XXXXXXXXXXXXXXXXXXXX",
-      "AWSSECRETKEY": "XXXXXXXXXXXXXXXXXXXXXXXX",
-      "BUCKET": "XXXXXXXXXXXXX"
-  },
-  "secretKey": "super duper secret key"
+    "CLOUD_API_URL": "http://localhost:8082/cloudapi",
+    "discordApiKeys": {
+        "CLIENT_ID": "XXXXXXXXXXXXXXXXXX",
+        "CLIENT_SECRET": "XXXXXXXXXXXXXXXXXX",
+        "REDIRECT_URI_DEV": "http%3A%2F%2Flocalhost%3A8080%2Fapi%2Fuser%2Fcallback&response_type=code&scope=identify",
+        "REDIRECT_URI_PROD": "http%3A%2F%2Fsce.engr.sjsu.edu%2Fprofile&response_type=code&scope=identify",
+        "REFRESH_TOKEN": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    },
+    "GENERAL_API_URL": "http://localhost:8080/api",
+    "githubApiKeys": {
+        "CLIENT_ID": "XXXXXXXXXXXXXXXXXXXX",
+        "CLIENT_SECRET": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    },
+    "googleApiKeys": {
+        "CLIENT_ID": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "CLIENT_SECRET": "XXXXXXXXXXXXXXXXXXXX",
+        "REDIRECT_URIS": [
+            "https://developers.google.com/oauthplayground"
+        ],
+        "REFRESH_TOKEN": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "USER": "sce.sjsu@gmail.com"
+    },
+    "googleCalendarIds": {
+        "PRIMARY_CAL": "primary",
+        "SCE_EVENTS_CAL": "XXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    },
+    "ledSignIp": "192.168.4.1",
+    "LOGGING_API_URL": "http://localhost:8081/loggingapi",
+    "passwordStrength": "medium",
+    "S3Bucket": {
+        "AWSACCESSKEYID": "XXXXXXXXXXXXXXXXXXXX",
+        "AWSSECRETKEY": "XXXXXXXXXXXXXXXXXXXXXXXX",
+        "BUCKET": "XXXXXXXXXXXXX"
+    },
+    "secretKey": "super duper secret key"
 }

--- a/api/main_endpoints/routes/User.js
+++ b/api/main_endpoints/routes/User.js
@@ -146,26 +146,26 @@ router.post('/edit', (req, res) => {
     return res.sendStatus(UNAUTHORIZED);
   }
 
-  if (!req.body.email) {
+  if(!req.body.email){
     return res.sendStatus(BAD_REQUEST);
   }
 
   let decoded = decodeToken(req);
-  if (decoded.accessLevel === membershipState.MEMBER) {
-    if (req.body.email && req.body.email != decoded.email) {
+  if(decoded.accessLevel === membershipState.MEMBER){
+    if(req.body.email && req.body.email != decoded.email){
       return res
         .status(UNAUTHORIZED)
         .send('Unauthorized to edit another user');
     }
-    if (req.body.accessLevel && req.body.accessLevel !== decoded.accessLevel) {
+    if(req.body.accessLevel && req.body.accessLevel !== decoded.accessLevel){
       return res
         .status(UNAUTHORIZED)
         .send('Unauthorized to change access level');
     }
   }
 
-  if (decoded.accessLevel === membershipState.OFFICER) {
-    if (req.body.accessLevel && req.body.accessLevel == membershipState.ADMIN) {
+  if(decoded.accessLevel === membershipState.OFFICER){
+    if(req.body.accessLevel && req.body.accessLevel == membershipState.ADMIN){
       return res.sendStatus(UNAUTHORIZED);
     }
   }

--- a/api/main_endpoints/routes/User.js
+++ b/api/main_endpoints/routes/User.js
@@ -146,26 +146,26 @@ router.post('/edit', (req, res) => {
     return res.sendStatus(UNAUTHORIZED);
   }
 
-  if(!req.body.email){
+  if (!req.body.email) {
     return res.sendStatus(BAD_REQUEST);
   }
 
   let decoded = decodeToken(req);
-  if(decoded.accessLevel === membershipState.MEMBER){
-    if(req.body.email && req.body.email != decoded.email){
+  if (decoded.accessLevel === membershipState.MEMBER) {
+    if (req.body.email && req.body.email != decoded.email) {
       return res
         .status(UNAUTHORIZED)
         .send('Unauthorized to edit another user');
     }
-    if(req.body.accessLevel && req.body.accessLevel !== decoded.accessLevel){
+    if (req.body.accessLevel && req.body.accessLevel !== decoded.accessLevel) {
       return res
         .status(UNAUTHORIZED)
         .send('Unauthorized to change access level');
     }
   }
 
-  if(decoded.accessLevel === membershipState.OFFICER){
-    if(req.body.accessLevel && req.body.accessLevel == membershipState.ADMIN){
+  if (decoded.accessLevel === membershipState.OFFICER) {
+    if (req.body.accessLevel && req.body.accessLevel == membershipState.ADMIN) {
       return res.sendStatus(UNAUTHORIZED);
     }
   }
@@ -262,7 +262,7 @@ router.post('/connectToDiscord', function(req, res) {
   return res.status(OK)
     .send('https://discord.com/api/oauth2/authorize?client_id=' +
       `${discordApiKeys.CLIENT_ID}` +
-      `&redirect_uri=${discordApiKeys.REDIRECT_URI_DEV}` +
+      `&redirect_uri=${discordApiKeys.REDIRECT_URI_PROD}` +
       `&state=${email}`);
 });
 

--- a/api/main_endpoints/util/discord-connection.js
+++ b/api/main_endpoints/util/discord-connection.js
@@ -11,7 +11,7 @@ async function loginWithDiscord(code, email) {
         `&client_id=${discordApiKeys.CLIENT_ID}` +
         `&client_secret=${discordApiKeys.CLIENT_SECRET}` +
         `&grant_type=authorization_code&code=${code}` +
-        `&redirect_uri=${discordApiKeys.REDIRECT_URI_DEV}`)
+        `&redirect_uri=${discordApiKeys.REDIRECT_URI_PROD}`)
       .then(response => {
         axios.get('https://discord.com/api/users/@me', {
           headers: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3221,9 +3221,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.784.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.784.0.tgz",
-      "integrity": "sha512-+KBkqH7t/XE91Fqn8eyJeNIWsnhSWL8bSUqFD7TfE3FN07MTlC0nprGYp+2WfcYNz5i8Bus1vY2DHNVhtTImnw==",
+      "version": "2.797.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.797.0.tgz",
+      "integrity": "sha512-fFc/2Xr7NkSXlZ9+2rCOFovA9NO1OnIyEaJFVwMM9gaqzucwRAfNNT0Pa1Kua5dhWrcf/mX0Z4mCDnTBf0/5mA==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -7655,9 +7655,9 @@
       }
     },
     "googleapis": {
-      "version": "63.0.0",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-63.0.0.tgz",
-      "integrity": "sha512-wixBalZFz9qLFJqKcEaKRAKuWAf20qw35/vVN/0ogfhIMlGuDUNE3groAPdaqAmaE3sTLSEe8+XRNIx3lxOhcQ==",
+      "version": "64.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-64.0.0.tgz",
+      "integrity": "sha512-o8m4aRVv/LdvTVMgH4tLNeQvJZrXaa+62L9wPaKg6nHlCN3dBCKWWQKOklCwtg18xpWY4/vdNuTPHb/9Lnd00A==",
       "requires": {
         "google-auth-library": "^6.0.0",
         "googleapis-common": "^4.4.1"
@@ -11839,9 +11839,9 @@
       "integrity": "sha512-YpzJOe2WFIW0V4ZkJQd/DGR/zdVwc/pI4Nl1CZrBO19FdRcSTmsuhdttw9rsTzzJLrNcSloLiBbEYx1C4f6gpA=="
     },
     "nodemailer": {
-      "version": "6.4.14",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.4.14.tgz",
-      "integrity": "sha512-0AQHOOT+nRAOK6QnksNaK7+5vjviVvEBzmZytKU7XSA+Vze2NLykTx/05ti1uJgXFTWrMq08u3j3x4r4OE6PAA=="
+      "version": "6.4.16",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.4.16.tgz",
+      "integrity": "sha512-68K0LgZ6hmZ7PVmwL78gzNdjpj5viqBdFqKrTtr9bZbJYj6BRj5W6WGkxXrEnUl3Co3CBXi3CZBUlpV/foGnOQ=="
     },
     "nodemon": {
       "version": "2.0.6",
@@ -14127,9 +14127,9 @@
       }
     },
     "react-chartjs-2": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-2.10.0.tgz",
-      "integrity": "sha512-1MjWEkUn8LLFf6GVyYUOrruJTW3yVU5hlEJOwGj3MiokuC+jH/BahjWVGAMonbe9UYbEIUbd2Rn36iVlC0Hb7w==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-2.11.1.tgz",
+      "integrity": "sha512-G7cNq/n2Bkh/v4vcI+GKx7Q1xwZexKYhOSj2HmrFXlvNeaURWXun6KlOUpEQwi1cv9Tgs4H3kGywDWMrX2kxfA==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.7.2"


### PR DESCRIPTION
# Changes made
Switches all Discord auth links from DEV (localhost ones) to PROD (SCE website)
Upon clicking "Change Discord Account," redirects to profile page

# To test
If there is a way into the official server, it is needed to see if Discord information (username/discriminator/userID) is stored in the database correctly. Storage is fine locally.