### PR TITLE
Weekly Mongodb Back Up Script

### DIFF
--- a/api/mongo_dump.sh
+++ b/api/mongo_dump.sh
@@ -1,15 +1,22 @@
 #!/bin/bash
 export PATH=/bin:/usr/bin:/usr/local/bin
-# change DUMP_DIR
-DUMP_DIR="/Users/admin/Desktop/sce/dbdump"
+# DUMP_DIR is the absolute path to the local backup directory
+DUMP_DIR="some path here"
 DB_NAME="sce_core"
-echo "Backing up databases"
+echo "Backing up sce_core"
 mongodump --db $DB_NAME --gzip --archive > $DUMP_DIR/$(date +"%d%b%Y")_$DB_NAME.gz
 echo "Done backing up sce_core"
-# restore command
+# Running this script:
+# set DUMP_DIR to the absolute path to the local backup directory
+# $ cd api
+# $ chmod +x mongo_dump.sh
+# $ ./mongo_dump.sh
+#
+# Restore command
 # mongorestore --gzip --archive=$DUMP_DIR/<dumpfilename> --db sce_core --noIndexRestore --drop
 # example: mongorestore --gzip --archive=/Users/admin/Desktop/sce/dbdump/11Jan2021.gz --db sce_core --noIndexRestore --drop
 # 
 # Running this script weekly using a crontab:
 # command line: sudo crontab -u <user> -e               # edit crontab
 # inside crontab: 0 0 * * 0 root <pathtothisscript>     # runs script on Sundays at 00:00 
+

--- a/api/weekly_dump.sh
+++ b/api/weekly_dump.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export PATH=/bin:/usr/bin:/usr/local/bin
+DATABASE_NAMES='ALL'
+if [ ${DATABASE_NAMES} = "ALL" ]; then
+ echo "Backing up databases"
+ mongodump
+fi

--- a/api/weekly_dump.sh
+++ b/api/weekly_dump.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
-#currently uses my paths
 export PATH=/bin:/usr/bin:/usr/local/bin
-DATABASE_NAMES='ALL'
-if [ ${DATABASE_NAMES} = "ALL" ]; then
- echo "Backing up databases"
- mkdir /Users/farahmasood/Desktop/dump/$(date +"%d%b%Y")
- mongodump -o /Users/farahmasood/Desktop/dump/$(date +"%d%b%Y")
- zip -r $(date +"%d%b%Y").zip /Users/farahmasood/Desktop/dump/$(date +"%d%b%Y")
- mv /Users/farahmasood/Documents/GitHub/Core-v4/$(date +"%d%b%Y").zip /Users/farahmasood/Desktop/dump
-fi
+# change DUMP_DIR to the absolute path to mongo dumps directory
+DUMP_DIR="/Users/admin/Desktop/sce/dbdump"
+PROJECT_DIR=$PWD
+DB_NAME="sce_core"
+echo "Backing up databases"
+mongodump --db $DB_NAME --gzip --archive > $DUMP_DIR/$(date +"%d%b%Y")_$DB_NAME.gzip
+echo "Done backing up sce_core"

--- a/api/weekly_dump.sh
+++ b/api/weekly_dump.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 export PATH=/bin:/usr/bin:/usr/local/bin
-# change DUMP_DIR to the absolute path to mongo dumps directory
+# change DUMP_DIR
 DUMP_DIR="/Users/admin/Desktop/sce/dbdump"
-PROJECT_DIR=$PWD
 DB_NAME="sce_core"
 echo "Backing up databases"
-mongodump --db $DB_NAME --gzip --archive > $DUMP_DIR/$(date +"%d%b%Y")_$DB_NAME.gzip
+mongodump --db $DB_NAME --gzip --archive > $DUMP_DIR/$(date +"%d%b%Y")_$DB_NAME.gz
 echo "Done backing up sce_core"
+# restore command
+# mongorestore --gzip --archive=$DUMP_DIR/<dumpfilename> --db sce_core --noIndexRestore --drop
+# example: mongorestore --gzip --archive=/Users/admin/Desktop/sce/dbdump/11Jan2021.gz --db sce_core --noIndexRestore --drop
+# 
+# Running this script weekly using a crontab:
+# command line: sudo crontab -u <user> -e               # edit crontab
+# inside crontab: 0 0 * * 0 root <pathtothisscript>     # runs script on Sundays at 00:00 

--- a/api/weekly_dump.sh
+++ b/api/weekly_dump.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+#currently uses my paths
 export PATH=/bin:/usr/bin:/usr/local/bin
 DATABASE_NAMES='ALL'
 if [ ${DATABASE_NAMES} = "ALL" ]; then
@@ -7,5 +7,5 @@ if [ ${DATABASE_NAMES} = "ALL" ]; then
  mkdir /Users/farahmasood/Desktop/dump/$(date +"%d%b%Y")
  mongodump -o /Users/farahmasood/Desktop/dump/$(date +"%d%b%Y")
  zip -r $(date +"%d%b%Y").zip /Users/farahmasood/Desktop/dump/$(date +"%d%b%Y")
- mv /Users/farahmasood/Documents/GitHub/Core-v4/07Jan2021.zip /Users/farahmasood/Desktop/dump
+ mv /Users/farahmasood/Documents/GitHub/Core-v4/$(date +"%d%b%Y").zip /Users/farahmasood/Desktop/dump
 fi

--- a/api/weekly_dump.sh
+++ b/api/weekly_dump.sh
@@ -4,5 +4,8 @@ export PATH=/bin:/usr/bin:/usr/local/bin
 DATABASE_NAMES='ALL'
 if [ ${DATABASE_NAMES} = "ALL" ]; then
  echo "Backing up databases"
- mongodump
+ mkdir /Users/farahmasood/Desktop/dump/$(date +"%d%b%Y")
+ mongodump -o /Users/farahmasood/Desktop/dump/$(date +"%d%b%Y")
+ zip -r $(date +"%d%b%Y").zip /Users/farahmasood/Desktop/dump/$(date +"%d%b%Y")
+ mv /Users/farahmasood/Documents/GitHub/Core-v4/07Jan2021.zip /Users/farahmasood/Desktop/dump
 fi


### PR DESCRIPTION
* backs up `sce_core` database in .gz format in the database dumps directory
* this script is meant to be run using a crontab

Testing:
In the script, change DUMP_DIR to a local dir where you'd like to backup
Running the script
```
$ cd api
$ chmod +x weekly_dump.sh
$ ./weekly_dump.sh
```