### PR TITLE
Use REST API instead of gRPC for LED Sign

### DIFF
--- a/api/logging_api/routes/LedSign.js
+++ b/api/logging_api/routes/LedSign.js
@@ -13,7 +13,6 @@ router.get('/healthCheck', (req, res) => {
       res.status(OK).send(response.data);
     })
     .catch(error => {
-      console.log(error);
       res.status(BAD_REQUEST).send(error);
     });
 });
@@ -24,7 +23,6 @@ router.post('/updateSignText', (req, res) => {
       res.status(OK).send(response.data);
     })
     .catch(error => {
-      console.log(error);
       res.status(BAD_REQUEST).send(error);
     });
 });

--- a/api/logging_api/routes/LedSign.js
+++ b/api/logging_api/routes/LedSign.js
@@ -1,7 +1,8 @@
 const express = require('express');
 const axios = require('axios');
 const router = express.Router();
-const { LED_SIGN_URL } = require('../../config/config.js'); 
+const { LED_SIGN_URL } = require('../../config/config.js');
+const { OK, BAD_REQUEST } = require('../../util/constants').STATUS_CODES;
 
 // send as part of request body which isn't present in url
 router.use(express.json());
@@ -9,20 +10,20 @@ router.use(express.json());
 router.get('/healthCheck', (req, res) => {
   axios.get(LED_SIGN_URL + 'api/health-check')
     .then(response => {
-      res.send(response.data);
+      res.status(OK).send(response.data);
     })
     .catch(error => {
-      console.error('ERROR', error);
+      res.status(BAD_REQUEST).send(error);
     });
 });
 
 router.post('/updateSignText', (req, res) => {
   axios.post(LED_SIGN_URL + 'api/update-sign', req.body)
     .then(response => {
-      res.send(response.data);
+      res.status(OK).send(response.data);
     })
     .catch(error => {
-      console.error('ERROR', error);
+      res.status(BAD_REQUEST).send(error);
     });
 });
 

--- a/api/logging_api/routes/LedSign.js
+++ b/api/logging_api/routes/LedSign.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const axios = require('axios');
+const router = express.Router();
+const { LED_SIGN_URL } = require('../../config/config.js'); 
+
+// send as part of request body which isn't present in url
+router.use(express.json());
+
+router.get('/healthCheck', (req, res) => {
+  axios.get(LED_SIGN_URL + 'api/health-check')
+    .then(response => {
+      res.send(response.data);
+    })
+    .catch(error => {
+      console.error('ERROR', error);
+    });
+});
+
+router.post('/updateSignText', (req, res) => {
+  axios.post(LED_SIGN_URL + 'api/update-sign', req.body)
+    .then(response => {
+      res.send(response.data);
+    })
+    .catch(error => {
+      console.error('ERROR', error);
+    });
+});
+
+module.exports = router;

--- a/api/logging_api/routes/LedSign.js
+++ b/api/logging_api/routes/LedSign.js
@@ -8,21 +8,23 @@ const { OK, BAD_REQUEST } = require('../../util/constants').STATUS_CODES;
 router.use(express.json());
 
 router.get('/healthCheck', (req, res) => {
-  axios.get(LED_SIGN_URL + 'api/health-check')
+  axios.get(LED_SIGN_URL + 'healthCheck')
     .then(response => {
       res.status(OK).send(response.data);
     })
     .catch(error => {
+      console.log(error);
       res.status(BAD_REQUEST).send(error);
     });
 });
 
 router.post('/updateSignText', (req, res) => {
-  axios.post(LED_SIGN_URL + 'api/update-sign', req.body)
+  axios.post(LED_SIGN_URL + 'updateSignText', req.body)
     .then(response => {
       res.status(OK).send(response.data);
     })
     .catch(error => {
+      console.log(error);
       res.status(BAD_REQUEST).send(error);
     });
 });

--- a/api/logging_api/server.js
+++ b/api/logging_api/server.js
@@ -8,7 +8,6 @@ function main() {
     __dirname + '/routes/LedSign.js'
   ];
   const loggingServer = new SceHttpServer(API_ENDPOINTS, 8081, '/meme/');
-  console.log(loggingServer);
   loggingServer.initializeEndpoints().then(() => {
     loggingServer.openConnection();
   });

--- a/api/logging_api/server.js
+++ b/api/logging_api/server.js
@@ -4,9 +4,11 @@ function main() {
   const API_ENDPOINTS = [
     __dirname + '/routes/ErrorLog.js',
     __dirname + '/routes/PrintLog.js',
-    __dirname + '/routes/SignLog.js'
+    __dirname + '/routes/SignLog.js',
+    __dirname + '/routes/LedSign.js'
   ];
-  const loggingServer = new SceHttpServer(API_ENDPOINTS, 8081, '/logapi/');
+  const loggingServer = new SceHttpServer(API_ENDPOINTS, 8081, '/meme/');
+  console.log(loggingServer);
   loggingServer.initializeEndpoints().then(() => {
     loggingServer.openConnection();
   });

--- a/api/util/SceHttpServer.js
+++ b/api/util/SceHttpServer.js
@@ -56,7 +56,6 @@ class SceHttpServer {
   async initializeEndpoints() {
     const requireList = await PathParser.parsePath(this.pathToEndpoints);
     requireList.map((route) => {
-      console.log('rr', this.prefix + route.endpointName);
       this.app.use(this.prefix + route.endpointName, require(route.filePath));
     });
   }

--- a/api/util/SceHttpServer.js
+++ b/api/util/SceHttpServer.js
@@ -56,6 +56,7 @@ class SceHttpServer {
   async initializeEndpoints() {
     const requireList = await PathParser.parsePath(this.pathToEndpoints);
     requireList.map((route) => {
+      console.log('rr', this.prefix + route.endpointName);
       this.app.use(this.prefix + route.endpointName, require(route.filePath));
     });
   }

--- a/src/APIFunctions/LedSign.js
+++ b/src/APIFunctions/LedSign.js
@@ -3,8 +3,6 @@ import { ApiResponse } from './ApiResponses';
 let config = require('../config/config.json');
 let LOGGING_API_URL = process.env.NODE_ENV === 'production' ?
   config.LOGGING_API_URL_PROD : config.LOGGING_API_URL;
-let RPC_API_URL = process.env.NODE_ENV === 'production' ?
-  config.RPC_API_URL_PROD : config.RPC_API_URL;
 
 /**
  * Checks to see if the sign is accepting requests. This is done
@@ -15,7 +13,7 @@ let RPC_API_URL = process.env.NODE_ENV === 'production' ?
 export async function healthCheck(officerName) {
   let status = new ApiResponse();
   await axios
-    .post(RPC_API_URL + '/LedSign/healthCheck', { officerName })
+    .get(LOGGING_API_URL + '/LedSign/healthCheck', { officerName })
     .then(res => {
       status.responseData = res.data;
     })
@@ -55,7 +53,7 @@ export async function getAllSignLogs() {
 export async function updateSignText(signData) {
   let status = new ApiResponse();
   await axios
-    .post(RPC_API_URL + '/LedSign/updateSignText', { ...signData })
+    .post(LOGGING_API_URL + '/LedSign/updateSignText', { ...signData })
     .then(res => {
       status = res.data;
     })


### PR DESCRIPTION
hotdog

Uses Express and Axios HTTP requests to connect to LED Sign server. Passes both LED sign health check and update when tested.