### PR TITLE
ESlint errors don't stop website from running anymore

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "api-test": "mocha",
     "frontend-test": "mocha --require @babel/register --require ignore-styles test/frontend/*.js",
-    "start": "react-scripts start",
+    "start": "ESLINT_NO_DEV_ERRORS=true react-scripts start",
     "server": "npm start --prefix api",
     "server-install": "npm install --prefix api",
     "build": "react-scripts build",


### PR DESCRIPTION
See this [stackoverflow answer](https://stackoverflow.com/a/64630234). `react-scripts` newer version causes eslint to run automatically with `npm run start`, causing the website to crash if there are any lint errors.

This PR prevents that from happening. Lint errors will be caught by PR builds and `npm run lint` instead.

See below example for lint failing:

<img width="1290" alt="Screen Shot 2021-11-18 at 5 53 15 PM" src="https://user-images.githubusercontent.com/63386979/142551318-51118461-229d-4877-a92d-ee5d40ffa4d5.png">
