### PR TITLE
Run GitHub actions on merge

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ dev ]
   push:
-    branches: [dev]
+    branches: [ dev ]
 
 jobs:
   build:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ dev ]
   push:
-    branches: [ dev ]
+    branches: [dev]
 
 jobs:
   build:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,6 +3,8 @@ name: Core-v4 Tests
 on:
   pull_request:
     branches: [ dev ]
+  push:
+    branches: [ dev ]
 
 jobs:
   build:


### PR DESCRIPTION
Similar to [SCE-discord-bot](https://github.com/SCE-Development/SCE-discord-bot), it would be nice to have a green check to show off our code on dev as passing. As of now, we only run the GitHub Actions build when a PR is opened. This changes it to also have the build be ran when dev is updated.