### PR TITLE
Removed mongo_dump.sh from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,7 +96,6 @@ sheets.json
 **/gp12-pem*
 **/is-ci*
 **/mime*
-**/mongo_dump*
 **/nodemon*
 **/nodetouch*
 **/nopt*


### PR DESCRIPTION
We actually need the `mongo_dump.sh` file because this script backs up the `sce_core` database in .gz format

more info regarding this file can be found here:
PR https://github.com/SCE-Development/Core-v4/pull/752
https://github.com/SCE-Development/Core-v4/blob/dev/api/mongo_dump.sh