### PR TITLE
Shows upcoming events on public events page

### DIFF
--- a/api/main_endpoints/routes/Event.js
+++ b/api/main_endpoints/routes/Event.js
@@ -1,36 +1,36 @@
-const express = require("express");
+const express = require('express');
 const router = express.Router();
-const Event = require("../models/Event");
+const Event = require('../models/Event');
 const {
   checkIfTokenSent,
   checkIfTokenValid,
-} = require("../../util/token-functions");
+} = require('../../util/token-functions');
 const { OK, BAD_REQUEST, UNAUTHORIZED, FORBIDDEN, NOT_FOUND } =
-  require("../../util/constants").STATUS_CODES;
-const addErrorLog = require("../util/logging-helpers");
-const membershipState = require("../../util/constants").MEMBERSHIP_STATE;
+  require('../../util/constants').STATUS_CODES;
+const addErrorLog = require('../util/logging-helpers');
+const membershipState = require('../../util/constants').MEMBERSHIP_STATE;
 
-router.get("/getEvents", (req, res) => {
+router.get('/getEvents', (req, res) => {
   Event.find()
     .sort({ eventDate: -1, startTime: -1 }) // Sort By date in descending order
     .then((items) => res.status(OK).send(items))
     .catch((error) => {
       const info = {
         errorTime: new Date(),
-        apiEndpoint: "Event/getEvents",
+        apiEndpoint: 'Event/getEvents',
         errorDescription: error,
       };
       addErrorLog(info);
-      res.status(BAD_REQUEST).send({ error, message: "Getting event failed" });
+      res.status(BAD_REQUEST).send({ error, message: 'Getting event failed' });
     });
 });
 
-router.get("/getUpcomingEvents", (req, res) => {
+router.get('/getUpcomingEvents', (req, res) => {
   const today = new Date(Date.now());
-  today.setHours(0,0,0,0);
+  today.setHours(0, 0, 0, 0);
   Event.find({
     eventDate: {
-      $gte: today.toISOString() //gets all upcoming events including today's
+      $gte: today.toISOString(), //gets all upcoming events including today's
     },
   })
     .sort({ eventDate: -1, startTime: -1 }) // Sort By date in descending order
@@ -38,15 +38,15 @@ router.get("/getUpcomingEvents", (req, res) => {
     .catch((error) => {
       const info = {
         errorTime: new Date(),
-        apiEndpoint: "Event/getEvents",
+        apiEndpoint: 'Event/getEvents',
         errorDescription: error,
       };
       addErrorLog(info);
-      res.status(BAD_REQUEST).send({ error, message: "Getting event failed" });
+      res.status(BAD_REQUEST).send({ error, message: 'Getting event failed' });
     });
 });
 
-router.post("/createEvent", (req, res) => {
+router.post('/createEvent', (req, res) => {
   if (!checkIfTokenSent(req)) {
     return res.sendStatus(FORBIDDEN);
   } else if (!checkIfTokenValid(req, membershipState.OFFICER)) {
@@ -71,7 +71,7 @@ router.post("/createEvent", (req, res) => {
   });
 });
 
-router.post("/editEvent", (req, res) => {
+router.post('/editEvent', (req, res) => {
   if (!checkIfTokenSent(req)) {
     return res.sendStatus(FORBIDDEN);
   } else if (!checkIfTokenValid(req, membershipState.OFFICER)) {
@@ -100,21 +100,21 @@ router.post("/editEvent", (req, res) => {
       event
         .save()
         .then((ret) => {
-          res.status(OK).json({ ret, event: "event updated successfully" });
+          res.status(OK).json({ ret, event: 'event updated successfully' });
         })
         .catch((error) => {
           res.status(BAD_REQUEST).send({
             error,
-            message: "event was not updated",
+            message: 'event was not updated',
           });
         });
     })
     .catch((error) => {
-      res.status(NOT_FOUND).send({ error, message: "event not found" });
+      res.status(NOT_FOUND).send({ error, message: 'event not found' });
     });
 });
 
-router.post("/deleteEvent", (req, res) => {
+router.post('/deleteEvent', (req, res) => {
   if (!checkIfTokenSent(req)) {
     return res.sendStatus(FORBIDDEN);
   } else if (!checkIfTokenValid(req, membershipState.OFFICER)) {
@@ -122,10 +122,10 @@ router.post("/deleteEvent", (req, res) => {
   }
   Event.deleteOne({ _id: req.body.id })
     .then((event) => {
-      res.status(OK).json({ event: "event successfully deleted" });
+      res.status(OK).json({ event: 'event successfully deleted' });
     })
     .catch((error) => {
-      res.status(BAD_REQUEST).send({ error, message: "deleting event failed" });
+      res.status(BAD_REQUEST).send({ error, message: 'deleting event failed' });
     });
 });
 

--- a/api/main_endpoints/routes/Event.js
+++ b/api/main_endpoints/routes/Event.js
@@ -15,7 +15,7 @@ const {
 const addErrorLog = require('../util/logging-helpers');
 const membershipState = require('../../util/constants').MEMBERSHIP_STATE;
 
-function getEvents(req, res, upcomingEvents) {
+function getEvents(res, upcomingEvents) {
   let query = {};
   if(upcomingEvents) {
     const today = new Date(Date.now());
@@ -40,11 +40,11 @@ function getEvents(req, res, upcomingEvents) {
 }
 
 router.get('/getEvents', (req, res) => {
-  getEvents(req, res, false);
+  getEvents(res, false);
 });
 
 router.get('/getUpcomingEvents', (req, res) => {
-  getEvents(req, res, true);
+  getEvents(res, true);
 });
 
 router.post('/createEvent', (req, res) => {

--- a/api/main_endpoints/routes/Event.js
+++ b/api/main_endpoints/routes/Event.js
@@ -22,7 +22,7 @@ function getEvents(req, res, upcomingEvents) {
     today.setHours(0, 0, 0, 0);
     query = {
       eventDate: { $gte: today.toISOString() }
-    }
+    };
   }
   Event.find(query)
     .sort({ eventDate: -1, startTime: -1 }) // Sort By date in descending order

--- a/api/main_endpoints/routes/Event.js
+++ b/api/main_endpoints/routes/Event.js
@@ -30,7 +30,7 @@ function getEvents(req, res, upcomingEvents) {
     .catch((error) => {
       const info = {
         errorTime: new Date(),
-        apiEndpoint: 'Event/getEvents',
+        apiEndpoint: (upcomingEvents) ? 'Event/getUpcomingEvents' : 'Event/getEvents',
         errorDescription: error,
       };
       addErrorLog(info);

--- a/api/main_endpoints/routes/Event.js
+++ b/api/main_endpoints/routes/Event.js
@@ -30,7 +30,7 @@ router.get("/getUpcomingEvents", (req, res) => {
   today.setHours(0,0,0,0);
   Event.find({
     eventDate: {
-      $gte: today.toISOString()
+      $gte: today.toISOString() //gets all upcoming events including today's
     },
   })
     .sort({ eventDate: -1, startTime: -1 }) // Sort By date in descending order

--- a/api/main_endpoints/routes/Event.js
+++ b/api/main_endpoints/routes/Event.js
@@ -30,6 +30,23 @@ router.get('/getEvents', (req, res) => {
     });
 });
 
+router.get('getUpcomingEvents', (req, res) => {
+  Event.find({eventDate: {
+    $gte: new Date(Date.now().setHours(00, 00, 00))
+  }})
+    .sort({ eventDate: -1, startTime: -1 }) // Sort By date in descending order
+    .then(items => res.status(OK).send(items))
+    .catch(error => {
+      const info = {
+        errorTime: new Date(),
+        apiEndpoint: 'Event/getEvents',
+        errorDescription: error
+      };
+      addErrorLog(info);
+      res.status(BAD_REQUEST).send({ error, message: 'Getting event failed' });
+    });
+});
+
 router.post('/createEvent', (req, res) => {
   if (!checkIfTokenSent(req)) {
     return res.sendStatus(FORBIDDEN);

--- a/api/main_endpoints/routes/Event.js
+++ b/api/main_endpoints/routes/Event.js
@@ -21,9 +21,7 @@ function getEvents(req, res, upcomingEvents) {
     const today = new Date(Date.now());
     today.setHours(0, 0, 0, 0);
     query = {
-      eventDate: {
-        $gte: today.toISOString(), // gets all upcoming events including today's
-      }
+      eventDate: { $gte: today.toISOString() }
     }
   }
   Event.find(query)
@@ -41,11 +39,11 @@ function getEvents(req, res, upcomingEvents) {
 }
 
 router.get('/getEvents', (req, res) => {
-  getEvents(req,res,false);
+  getEvents(req, res, false);
 });
 
 router.get('/getUpcomingEvents', (req, res) => {
-  getEvents(req,res,true);
+  getEvents(req, res, true);
 });
 
 router.post('/createEvent', (req, res) => {

--- a/api/main_endpoints/routes/Event.js
+++ b/api/main_endpoints/routes/Event.js
@@ -1,53 +1,52 @@
-const express = require('express');
+const express = require("express");
 const router = express.Router();
-const Event = require('../models/Event');
+const Event = require("../models/Event");
 const {
   checkIfTokenSent,
-  checkIfTokenValid
-} = require('../../util/token-functions');
-const {
-  OK,
-  BAD_REQUEST,
-  UNAUTHORIZED,
-  FORBIDDEN,
-  NOT_FOUND
-} = require('../../util/constants').STATUS_CODES;
-const addErrorLog = require ('../util/logging-helpers');
-const membershipState = require('../../util/constants').MEMBERSHIP_STATE;
+  checkIfTokenValid,
+} = require("../../util/token-functions");
+const { OK, BAD_REQUEST, UNAUTHORIZED, FORBIDDEN, NOT_FOUND } =
+  require("../../util/constants").STATUS_CODES;
+const addErrorLog = require("../util/logging-helpers");
+const membershipState = require("../../util/constants").MEMBERSHIP_STATE;
 
-router.get('/getEvents', (req, res) => {
+router.get("/getEvents", (req, res) => {
   Event.find()
     .sort({ eventDate: -1, startTime: -1 }) // Sort By date in descending order
-    .then(items => res.status(OK).send(items))
-    .catch(error => {
+    .then((items) => res.status(OK).send(items))
+    .catch((error) => {
       const info = {
         errorTime: new Date(),
-        apiEndpoint: 'Event/getEvents',
-        errorDescription: error
+        apiEndpoint: "Event/getEvents",
+        errorDescription: error,
       };
       addErrorLog(info);
-      res.status(BAD_REQUEST).send({ error, message: 'Getting event failed' });
+      res.status(BAD_REQUEST).send({ error, message: "Getting event failed" });
     });
 });
 
-router.get('getUpcomingEvents', (req, res) => {
-  Event.find({eventDate: {
-    $gte: new Date(Date.now().setHours(00, 00, 00))
-  }})
+router.get("/getUpcomingEvents", (req, res) => {
+  const today = new Date(Date.now());
+  today.setHours(0,0,0,0);
+  Event.find({
+    eventDate: {
+      $gte: today.toISOString()
+    },
+  })
     .sort({ eventDate: -1, startTime: -1 }) // Sort By date in descending order
-    .then(items => res.status(OK).send(items))
-    .catch(error => {
+    .then((items) => res.status(OK).send(items))
+    .catch((error) => {
       const info = {
         errorTime: new Date(),
-        apiEndpoint: 'Event/getEvents',
-        errorDescription: error
+        apiEndpoint: "Event/getEvents",
+        errorDescription: error,
       };
       addErrorLog(info);
-      res.status(BAD_REQUEST).send({ error, message: 'Getting event failed' });
+      res.status(BAD_REQUEST).send({ error, message: "Getting event failed" });
     });
 });
 
-router.post('/createEvent', (req, res) => {
+router.post("/createEvent", (req, res) => {
   if (!checkIfTokenSent(req)) {
     return res.sendStatus(FORBIDDEN);
   } else if (!checkIfTokenValid(req, membershipState.OFFICER)) {
@@ -61,7 +60,7 @@ router.post('/createEvent', (req, res) => {
     startTime: req.body.startTime,
     endTime: req.body.endTime,
     eventCategory: req.body.eventCategory,
-    imageURL: req.body.imageURL
+    imageURL: req.body.imageURL,
   });
 
   Event.create(newEvent, (error, post) => {
@@ -72,7 +71,7 @@ router.post('/createEvent', (req, res) => {
   });
 });
 
-router.post('/editEvent', (req, res) => {
+router.post("/editEvent", (req, res) => {
   if (!checkIfTokenSent(req)) {
     return res.sendStatus(FORBIDDEN);
   } else if (!checkIfTokenValid(req, membershipState.OFFICER)) {
@@ -86,10 +85,10 @@ router.post('/editEvent', (req, res) => {
     startTime,
     endTime,
     eventCategory,
-    imageURL
+    imageURL,
   } = req.body;
   Event.findOne({ _id: req.body.id })
-    .then(event => {
+    .then((event) => {
       event.title = title || event.title;
       event.description = description || event.description;
       event.eventLocation = eventLocation || event.eventLocation;
@@ -100,33 +99,33 @@ router.post('/editEvent', (req, res) => {
       event.imageURL = imageURL || event.imageURL;
       event
         .save()
-        .then(ret => {
-          res.status(OK).json({ ret, event: 'event updated successfully' });
+        .then((ret) => {
+          res.status(OK).json({ ret, event: "event updated successfully" });
         })
-        .catch(error => {
+        .catch((error) => {
           res.status(BAD_REQUEST).send({
             error,
-            message: 'event was not updated'
+            message: "event was not updated",
           });
         });
     })
-    .catch(error => {
-      res.status(NOT_FOUND).send({ error, message: 'event not found' });
+    .catch((error) => {
+      res.status(NOT_FOUND).send({ error, message: "event not found" });
     });
 });
 
-router.post('/deleteEvent', (req, res) => {
+router.post("/deleteEvent", (req, res) => {
   if (!checkIfTokenSent(req)) {
     return res.sendStatus(FORBIDDEN);
   } else if (!checkIfTokenValid(req, membershipState.OFFICER)) {
     return res.sendStatus(UNAUTHORIZED);
   }
   Event.deleteOne({ _id: req.body.id })
-    .then(event => {
-      res.status(OK).json({ event: 'event successfully deleted' });
+    .then((event) => {
+      res.status(OK).json({ event: "event successfully deleted" });
     })
-    .catch(error => {
-      res.status(BAD_REQUEST).send({ error, message: 'deleting event failed' });
+    .catch((error) => {
+      res.status(BAD_REQUEST).send({ error, message: "deleting event failed" });
     });
 });
 

--- a/api/main_endpoints/routes/Event.js
+++ b/api/main_endpoints/routes/Event.js
@@ -30,7 +30,7 @@ router.get('/getUpcomingEvents', (req, res) => {
   today.setHours(0, 0, 0, 0);
   Event.find({
     eventDate: {
-      $gte: today.toISOString(), //gets all upcoming events including today's
+      $gte: today.toISOString(), // gets all upcoming events including today's
     },
   })
     .sort({ eventDate: -1, startTime: -1 }) // Sort By date in descending order

--- a/api/main_endpoints/routes/Event.js
+++ b/api/main_endpoints/routes/Event.js
@@ -30,7 +30,8 @@ function getEvents(req, res, upcomingEvents) {
     .catch((error) => {
       const info = {
         errorTime: new Date(),
-        apiEndpoint: (upcomingEvents) ? 'Event/getUpcomingEvents' : 'Event/getEvents',
+        apiEndpoint: 
+          (upcomingEvents) ? 'Event/getUpcomingEvents' : 'Event/getEvents',
         errorDescription: error,
       };
       addErrorLog(info);

--- a/api/main_endpoints/routes/Event.js
+++ b/api/main_endpoints/routes/Event.js
@@ -5,8 +5,13 @@ const {
   checkIfTokenSent,
   checkIfTokenValid,
 } = require('../../util/token-functions');
-const { OK, BAD_REQUEST, UNAUTHORIZED, FORBIDDEN, NOT_FOUND } =
-  require('../../util/constants').STATUS_CODES;
+const {
+  OK,
+  BAD_REQUEST,
+  UNAUTHORIZED,
+  FORBIDDEN,
+  NOT_FOUND
+} = require('../../util/constants').STATUS_CODES;
 const addErrorLog = require('../util/logging-helpers');
 const membershipState = require('../../util/constants').MEMBERSHIP_STATE;
 
@@ -39,7 +44,7 @@ router.get('/getUpcomingEvents', (req, res) => {
       const info = {
         errorTime: new Date(),
         apiEndpoint: 'Event/getEvents',
-        errorDescription: error,
+        errorDescription: error
       };
       addErrorLog(info);
       res.status(BAD_REQUEST).send({ error, message: 'Getting event failed' });
@@ -60,7 +65,7 @@ router.post('/createEvent', (req, res) => {
     startTime: req.body.startTime,
     endTime: req.body.endTime,
     eventCategory: req.body.eventCategory,
-    imageURL: req.body.imageURL,
+    imageURL: req.body.imageURL
   });
 
   Event.create(newEvent, (error, post) => {
@@ -85,10 +90,10 @@ router.post('/editEvent', (req, res) => {
     startTime,
     endTime,
     eventCategory,
-    imageURL,
+    imageURL
   } = req.body;
   Event.findOne({ _id: req.body.id })
-    .then((event) => {
+    .then(event => {
       event.title = title || event.title;
       event.description = description || event.description;
       event.eventLocation = eventLocation || event.eventLocation;
@@ -99,17 +104,17 @@ router.post('/editEvent', (req, res) => {
       event.imageURL = imageURL || event.imageURL;
       event
         .save()
-        .then((ret) => {
+        .then(ret => {
           res.status(OK).json({ ret, event: 'event updated successfully' });
         })
-        .catch((error) => {
+        .catch(error => {
           res.status(BAD_REQUEST).send({
             error,
-            message: 'event was not updated',
+            message: 'event was not updated'
           });
         });
     })
-    .catch((error) => {
+    .catch(error => {
       res.status(NOT_FOUND).send({ error, message: 'event not found' });
     });
 });
@@ -121,10 +126,10 @@ router.post('/deleteEvent', (req, res) => {
     return res.sendStatus(UNAUTHORIZED);
   }
   Event.deleteOne({ _id: req.body.id })
-    .then((event) => {
+    .then(event => {
       res.status(OK).json({ event: 'event successfully deleted' });
     })
-    .catch((error) => {
+    .catch(error => {
       res.status(BAD_REQUEST).send({ error, message: 'deleting event failed' });
     });
 });

--- a/api/main_endpoints/routes/Event.js
+++ b/api/main_endpoints/routes/Event.js
@@ -15,8 +15,18 @@ const {
 const addErrorLog = require('../util/logging-helpers');
 const membershipState = require('../../util/constants').MEMBERSHIP_STATE;
 
-router.get('/getEvents', (req, res) => {
-  Event.find()
+function getEvents(req, res, upcomingEvents) {
+  let query = {};
+  if(upcomingEvents) {
+    const today = new Date(Date.now());
+    today.setHours(0, 0, 0, 0);
+    query = {
+      eventDate: {
+        $gte: today.toISOString(), // gets all upcoming events including today's
+      }
+    }
+  }
+  Event.find(query)
     .sort({ eventDate: -1, startTime: -1 }) // Sort By date in descending order
     .then((items) => res.status(OK).send(items))
     .catch((error) => {
@@ -28,27 +38,14 @@ router.get('/getEvents', (req, res) => {
       addErrorLog(info);
       res.status(BAD_REQUEST).send({ error, message: 'Getting event failed' });
     });
+}
+
+router.get('/getEvents', (req, res) => {
+  getEvents(req,res,false);
 });
 
 router.get('/getUpcomingEvents', (req, res) => {
-  const today = new Date(Date.now());
-  today.setHours(0, 0, 0, 0);
-  Event.find({
-    eventDate: {
-      $gte: today.toISOString(), // gets all upcoming events including today's
-    },
-  })
-    .sort({ eventDate: -1, startTime: -1 }) // Sort By date in descending order
-    .then((items) => res.status(OK).send(items))
-    .catch((error) => {
-      const info = {
-        errorTime: new Date(),
-        apiEndpoint: 'Event/getEvents',
-        errorDescription: error
-      };
-      addErrorLog(info);
-      res.status(BAD_REQUEST).send({ error, message: 'Getting event failed' });
-    });
+  getEvents(req,res,true);
 });
 
 router.post('/createEvent', (req, res) => {

--- a/api/main_endpoints/routes/Event.js
+++ b/api/main_endpoints/routes/Event.js
@@ -30,7 +30,7 @@ function getEvents(req, res, upcomingEvents) {
     .catch((error) => {
       const info = {
         errorTime: new Date(),
-        apiEndpoint: 
+        apiEndpoint:
           (upcomingEvents) ? 'Event/getUpcomingEvents' : 'Event/getEvents',
         errorDescription: error,
       };

--- a/src/APIFunctions/Event.js
+++ b/src/APIFunctions/Event.js
@@ -35,6 +35,20 @@ export async function getAllEvents() {
   return status;
 }
 
+export async function getUpcomingEvents() {
+  let status = new ApiResponse();
+  await axios
+    .get(GENERAL_API_URL+'/event/getUpcomingEvents')
+    .then(res => {
+      status.responseData = res.data;
+    })
+    .catch(err => {
+      status.responseData = err;
+      status.error = true;
+    });
+  return status;
+}
+
 /**
  * Handles the case in which the image URL is not valid
  * @param {string} url an image url to be added to an event

--- a/src/Pages/Events/EventList.js
+++ b/src/Pages/Events/EventList.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Container } from 'reactstrap';
 import './event-page.css';
-import { getAllEvents } from '../../APIFunctions/Event';
+import { getUpcomingEvents } from '../../APIFunctions/Event';
 import EventCard from './EventCard';
 import Header from '../../Components/Header/Header';
 
@@ -15,7 +15,7 @@ function AnnouncementList() {
   };
 
   async function populateEventList() {
-    const eventResponse = await getAllEvents();
+    const eventResponse = await getUpcomingEvents();
     if (!eventResponse.error) setEventList(eventResponse.responseData);
   }
 

--- a/test/Event.js
+++ b/test/Event.js
@@ -229,7 +229,7 @@ describe('Event', () => {
     });
   });
   describe('/GET getUpcomingEvents', () => {
-    it('Should return 404 if no upcoming events are available', async () => {
+    it('Should return an empty array if no upcoming events are available', async () => {
       setTokenStatus(true);
       const result = await test.sendGetRequest(
         '/api/event/getUpcomingEvents');
@@ -238,7 +238,7 @@ describe('Event', () => {
       getEventsResponse.should.be.a('array');
       expect(getEventsResponse).to.have.length(0);
     });
-    it('Should return 200 if there are upcoming events', async () => {
+    it('Should return all upcoming events', async () => {
       setTokenStatus(true);
       const create1 = await test.sendPostRequestWithToken(
         token, '/api/event/createEvent', TOMORROWS_EVENT);

--- a/test/Event.js
+++ b/test/Event.js
@@ -79,7 +79,29 @@ describe('Event', () => {
     eventCategory: 'game night',
     imageURL: 'https://link.to/pdf'
   };
-
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const YESTERDAYS_EVENT = {
+    title: 'yesterday\'s event',
+    eventLocation: 'ENGR 294',
+    eventDate: yesterday,
+    startTime: '13:00',
+    endTime: '14:00',
+    eventCategory: 'game night',
+    imageURL: 'https://link.to/pdf'
+  }
+  const tomorrow = new Date(today);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const TOMORROWS_EVENT = {
+    title: 'tomorrow\'s event',
+    eventLocation: 'ENGR 294',
+    eventDate: tomorrow,
+    startTime: '13:00',
+    endTime: '14:00',
+    eventCategory: 'game night',
+    imageURL: 'https://link.to/pdf'
+  }
   describe('/POST createEvent', () => {
     it('Should return 403 when an invalid token is supplied', async () => {
       const result = await test.sendPostRequest(
@@ -204,6 +226,37 @@ describe('Event', () => {
       const getEventsResponse = result.body;
       getEventsResponse.should.be.a('array');
       expect(getEventsResponse).to.have.length(0);
+    });
+  });
+  describe('/GET getUpcomingEvents', () => {
+    it('Should return 404 if no upcoming events are available', async () => {
+      setTokenStatus(true);
+      const result = await test.sendGetRequest(
+        '/api/event/getUpcomingEvents');
+      expect(result).to.have.status(OK);
+      const getEventsResponse = result.body;
+      getEventsResponse.should.be.a('array');
+      expect(getEventsResponse).to.have.length(0);
+    });
+    it('Should return 200 if there are upcoming events', async () => {
+      setTokenStatus(true);
+      const create1 = await test.sendPostRequestWithToken(
+        token, '/api/event/createEvent', TOMORROWS_EVENT);
+      expect(create1).to.have.status(OK);
+      const create2 = await test.sendPostRequestWithToken(
+        token, '/api/event/createEvent', YESTERDAYS_EVENT);
+      expect(create2).to.have.status(OK);
+      const result = await test.sendGetRequest(
+        '/api/event/getUpcomingEvents');
+      expect(result).to.have.status(OK);
+      const getUpcomingEventsResponse = result.body;
+      getUpcomingEventsResponse.should.be.a('array');
+      expect(getUpcomingEventsResponse).to.have.length(1);
+      expect(new Date(getUpcomingEventsResponse[0].eventDate) >= today);
+      const getEvents = await test.sendGetRequest('/api/event/getEvents');
+      const getEventsResponse = getEvents.body;
+      getEventsResponse.should.be.a('array');
+      expect(getEventsResponse).to.have.length(2);
     });
   });
 });

--- a/test/Event.js
+++ b/test/Event.js
@@ -229,7 +229,8 @@ describe('Event', () => {
     });
   });
   describe('/GET getUpcomingEvents', () => {
-    it('Should return an empty array if no upcoming events are available', async () => {
+    it('Should return an empty array if no'+
+        'upcoming events are available', async () => {
       setTokenStatus(true);
       const result = await test.sendGetRequest(
         '/api/event/getUpcomingEvents');

--- a/test/Event.js
+++ b/test/Event.js
@@ -90,7 +90,7 @@ describe('Event', () => {
     endTime: '14:00',
     eventCategory: 'game night',
     imageURL: 'https://link.to/pdf'
-  }
+  };
   const tomorrow = new Date(today);
   tomorrow.setDate(tomorrow.getDate() + 1);
   const TOMORROWS_EVENT = {
@@ -101,7 +101,7 @@ describe('Event', () => {
     endTime: '14:00',
     eventCategory: 'game night',
     imageURL: 'https://link.to/pdf'
-  }
+  };
   describe('/POST createEvent', () => {
     it('Should return 403 when an invalid token is supplied', async () => {
       const result = await test.sendPostRequest(

--- a/test/frontend/EventList.test.js
+++ b/test/frontend/EventList.test.js
@@ -58,7 +58,7 @@ describe('<EventList />', () => {
   ]);
 
   before(done => {
-    stub = sinon.stub(EventAPI, 'getAllEvents');
+    stub = sinon.stub(EventAPI, 'getUpcomingEvents');
     done();
   });
 


### PR DESCRIPTION
### Resolves #926 
- created API that retrieves all upcoming events (including today's)
- created API function for `events/getUpcomingEvents`
- updated public event page to populate the page with all upcoming events by calling `getUpcomingEvents()` api function

> Note: Public view shows only upcoming events while admin view (event manager) shows all events as seen below (look at the dates).


#### Public view: 
<img src="https://user-images.githubusercontent.com/75186517/147422343-98ebbe20-b9a5-4c14-845b-b1577b84616e.png" alt="" width="350"/>

#### Admin view (as Event Manager): 
<img src="https://user-images.githubusercontent.com/75186517/147422385-7ad29fa2-e63c-4192-838a-9bf717c65ee1.png" alt="" width="350"/>
<img src="https://user-images.githubusercontent.com/75186517/147422401-84def357-0983-4e40-bdb2-19e76a412241.png" alt="" width="350"/>


