### PR TITLE
Removes filtered events function

### DIFF
--- a/src/Pages/Events/EventList.js
+++ b/src/Pages/Events/EventList.js
@@ -34,13 +34,13 @@ function AnnouncementList() {
             return (
               <EventCard
                 key={index}
-                isEventManager={false}
+                isEventManager = {false}
                 {...event}
               />
             );
           })
         ) : (
-          <h1 className='no-event-list'>No events yet!</h1>
+          <h1 className = 'no-event-list'>No events yet!</h1>
         )}
       </Container>
     </React.Fragment>

--- a/src/Pages/Events/EventList.js
+++ b/src/Pages/Events/EventList.js
@@ -7,7 +7,6 @@ import Header from '../../Components/Header/Header';
 
 function AnnouncementList() {
   const [eventList, setEventList] = useState();
-  const [validList, setValidList] = useState();
 
   const headerProps = {
     title: 'SCE Event Page'
@@ -29,8 +28,8 @@ function AnnouncementList() {
     <React.Fragment>
       <Header {...headerProps} />
       <Container className='event-list'>
-        {validList && validList.length ? (
-          validList.reverse().map((event, index) => {
+        {eventList && eventList.length ? (
+          eventList.reverse().map((event, index) => {
             return (
               <EventCard
                 key={index}

--- a/src/Pages/Events/EventList.js
+++ b/src/Pages/Events/EventList.js
@@ -6,7 +6,6 @@ import EventCard from './EventCard';
 import Header from '../../Components/Header/Header';
 
 function AnnouncementList() {
-  const [getFiltered, setGetFiltered] = useState(true);
   const [eventList, setEventList] = useState();
   const [validList, setValidList] = useState();
 
@@ -19,23 +18,6 @@ function AnnouncementList() {
     if (!eventResponse.error) setEventList(eventResponse.responseData);
   }
 
-  const getFilteredEvents= () => {
-    if (getFiltered){
-      try {
-        let currDate = new Date();
-        currDate.setDate(currDate.getDate() -1);
-        let validList = [];
-        eventList.forEach(item => {
-          let date = new Date(item.eventDate);
-          if (date >= currDate) {
-            validList.push(item);
-          }
-        }, setValidList(validList), setGetFiltered(false));
-      } catch (error) {
-      }
-    }
-  };
-
   useEffect(() => {
     async function fetchData() {
       await populateEventList();
@@ -47,19 +29,18 @@ function AnnouncementList() {
     <React.Fragment>
       <Header {...headerProps} />
       <Container className='event-list'>
-        {getFilteredEvents()}
         {validList && validList.length ? (
           validList.reverse().map((event, index) => {
             return (
               <EventCard
                 key={index}
-                isEventManager = {false}
+                isEventManager={false}
                 {...event}
               />
             );
           })
         ) : (
-          <h1 className = 'no-event-list'>No events yet!</h1>
+          <h1 className='no-event-list'>No events yet!</h1>
         )}
       </Container>
     </React.Fragment>

--- a/test/frontend/EventList.test.js
+++ b/test/frontend/EventList.test.js
@@ -20,7 +20,6 @@ describe('<EventList />', () => {
    * UNEXPIRED_EVENTS_COUNT: event with dates that include
    * today's date and the dates after.
    */
-  const UNEXPIRED_EVENTS_COUNT = 3;
   const RENDERED_EVENTS = new ApiResponse(false, [
     {
       title: 'Expired',
@@ -76,14 +75,14 @@ describe('<EventList />', () => {
   }
 
   it(
-    'Should render an <EventCard /> component for every unexpired event card ' +
+    'Should render an <EventCard /> component for every event given ' +
       'in event list array',
     async () => {
       returnEventArray();
       const wrapper = await mount(<EventList {...RENDERED_EVENTS} />);
       wrapper.update();
       expect(wrapper.find(EventCard)).to.have.lengthOf(
-        UNEXPIRED_EVENTS_COUNT
+        RENDERED_EVENTS.responseData.length
       );
     }
   );


### PR DESCRIPTION
With @neelp03 integrating a fresh, [new way of organizing the events list in a way that makes sense](https://github.com/SCE-Development/Core-v4/pull/933), we can remove the unnecessary function `getFilteredEvents` along with its corresponding states.