### PR TITLE
Fix Create New Event Double Click

### DIFF
--- a/src/Pages/EventManager/EventManagerModal.js
+++ b/src/Pages/EventManager/EventManagerModal.js
@@ -32,7 +32,6 @@ function EventManagerModal(props) {
   const [eventCategory, setEventCategory] = useState(props.eventCategory);
   const [imagePreviewURL, setImagePreviewURL] = useState(NOT_FOUND_PNG);
   const [clickedSubmit, setClickedSubmit] = useState(false);
-  const [requiredFieldsFilled, setRequiredFieldsFilled] = useState(false);
 
   function toggleConfirmationModal() {
     setConfirmationModal(!confirmationModal);
@@ -150,7 +149,7 @@ function EventManagerModal(props) {
     return false;
   }
 
-  async function handleSubmission() {
+  async function handleSubmission(requiredFieldsFilled) {
     setClickedSubmit(true);
     if (requiredFieldsFilled) {
       const eventFields = {
@@ -177,8 +176,7 @@ function EventManagerModal(props) {
 
   function processRequest() {
     const passed = requiredFieldsFilledIn();
-    setRequiredFieldsFilled(passed);
-    handleSubmission();
+    handleSubmission(passed);
   }
 
   async function handleURLChange(url) {


### PR DESCRIPTION
## Having to click twice for creating a new event is nevermore.
- previously, `Create New Event` button in EventManager.js requires you to click twice. @evanugarte noticed that props are async and thus the logic for creating sequentially was broken. 
- this bug was introduced by @evanugarte with #225. very sad.

**BEFORE**: This button was broken. See Below

![image](https://user-images.githubusercontent.com/63386979/147843309-387b1780-adde-4d4b-b081-86f32103004f.png)

**AFTER**: This button is not broken. See Below

![image](https://user-images.githubusercontent.com/63386979/147843317-84b364bc-f27d-45de-ae03-294a432ead5c.png)

## Features
- [X] reduces required clicks from 2 to 1!!!! 💯 🔛 🔝 🔜 