### PR TITLE
Add schema for password reset 

### DIFF
--- a/api/main_endpoints/models/password-reset.js
+++ b/api/main_endpoints/models/password-reset.js
@@ -1,0 +1,23 @@
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const PasswordReset = new Schema(
+  {
+    email: {
+      type: String,
+      required: true
+    },
+    token: {
+      type: String,
+      required: true
+    },
+    createdAt: {
+      type: Date,
+      default: Date.now,
+      required: true,
+      index: {  expires: '1h' }
+    }
+  }
+);
+
+module.exports = mongoose.model('PasswordReset', PasswordReset);

--- a/api/main_endpoints/models/password-reset.js
+++ b/api/main_endpoints/models/password-reset.js
@@ -1,7 +1,7 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
-const PasswordReset = new Schema(
+const PasswordResetSchema = new Schema(
   {
     email: {
       type: String,


### PR DESCRIPTION
Add MongoDB schema for password reset token.

New collection: `passwordresets`
Document fields:
- `email`
This field is used to indicate the user that requests the reset. A new document is created only if the user exists.
- `token`
A token is generated and stored with the email. The token is embedded in the link sent to the user. The token is used to  authenticate accessing the reset page and submitting password update.  If a document related to the user exists, the existing token will be updated with the newly generated one. When the password update is submitted successfully, the document is removed.
- `createdAt`
  ```javascript
  createdAt: {
        type: Date,
        default: Date.now,
        required: true,
        index: {  expires: '1h' }
  }
  ```
  This field ensures that MongoDB will automatically remove the document after 1 hour.