### PR TITLE
Give Eslint warnings instead of errors when running website

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,38 @@
+import subprocess
 import platform
 import os
+
+def write_alias_to_file(file_name):
+    try:
+        subprocess.check_call(
+            f'grep -rl \"alias ESLINT_NO_DEV_ERRORS=true\"',
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
+    except subprocess.CalledProcessError:
+        with open(file_name, 'a') as file:
+            file.write('\n')
+            file.write(f"export ESLINT_NO_DEV_ERRORS=true")
+            file.write('\n')
+
+def add_alias_unix():
+    HOME_PATH = os.environ["HOME"]
+    BASHRC_PATH = f'{HOME_PATH}/.bashrc'
+    if platform.system() == "Darwin":
+        ZSHRC_PATH = f"{HOME_PATH}/.zshrc"
+        if os.path.isfile(BASHRC_PATH):
+            write_alias_to_file(BASHRC_PATH)
+        if os.path.isfile(ZSHRC_PATH):
+            write_alias_to_file(ZSHRC_PATH)
+    elif platform.system() == "Linux":
+        BASH_PROFILE_PATH = f"{HOME_PATH}/.bash_profile"
+        if os.path.isfile(BASHRC_PATH):
+            write_alias_to_file(BASHRC_PATH)
+        elif os.path.isfile(BASH_PROFILE_PATH):
+            write_alias_to_file(BASH_PROFILE_PATH)
+
+def add_alias_windows():
+    subprocess.check_call("setx ESLINT_NO_DEV_ERRORS true",
+                             stderr=subprocess.STDOUT, shell = True)
+
 
 print('Welcome to SCE-Development Setup!\n')
 user_os = platform.system()
@@ -10,10 +43,12 @@ if user_os == 'Darwin' or user_os == 'Linux':
         os.system("cp api/config/config.example.json  api/config/config.json")
     if os.path.exists("src/config/config.json") == False:
         os.system("cp src/config/config.example.json  src/config/config.json")
+    add_alias_unix()
 elif user_os == 'Windows':
     if os.path.exists("api\config\config.json") == False:
         os.system("copy api\config\config.example.json  api\config\config.json")
     if os.path.exists("src\config\config.json") == False:
         os.system("copy src\config\config.example.json  src\config\config.json")
+    add_alias_windows()
 
 print('\nSetup complete! Bye!\n')

--- a/setup.py
+++ b/setup.py
@@ -2,16 +2,13 @@ import subprocess
 import platform
 import os
 
-def write_alias_to_file(file_name):
-    try:
-        subprocess.check_call(
-            f'grep -rl \"alias ESLINT_NO_DEV_ERRORS=true\"',
-            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
-    except subprocess.CalledProcessError:
-        with open(file_name, 'a') as file:
-            file.write('\n')
-            file.write(f"export ESLINT_NO_DEV_ERRORS=true")
-            file.write('\n')
+def write_to_file(file_name):
+    with open(file_name, 'a') as file:
+        file.write('\n')
+        file.write("export ESLINT_NO_DEV_ERRORS=true")
+        file.write('\n')
+    print(f"\n{file_name} written! " +
+        "Open a new terminal after completing setup for changes to be in effect.")
 
 def add_alias_unix():
     HOME_PATH = os.environ["HOME"]
@@ -19,15 +16,15 @@ def add_alias_unix():
     if platform.system() == "Darwin":
         ZSHRC_PATH = f"{HOME_PATH}/.zshrc"
         if os.path.isfile(BASHRC_PATH):
-            write_alias_to_file(BASHRC_PATH)
+            write_to_file(BASHRC_PATH)
         if os.path.isfile(ZSHRC_PATH):
-            write_alias_to_file(ZSHRC_PATH)
+            write_to_file(ZSHRC_PATH)
     elif platform.system() == "Linux":
         BASH_PROFILE_PATH = f"{HOME_PATH}/.bash_profile"
         if os.path.isfile(BASHRC_PATH):
-            write_alias_to_file(BASHRC_PATH)
+            write_to_file(BASHRC_PATH)
         elif os.path.isfile(BASH_PROFILE_PATH):
-            write_alias_to_file(BASH_PROFILE_PATH)
+            write_to_file(BASH_PROFILE_PATH)
 
 def add_alias_windows():
     subprocess.check_call("setx ESLINT_NO_DEV_ERRORS true",

--- a/setup.py
+++ b/setup.py
@@ -13,18 +13,15 @@ def write_to_file(file_name):
 def add_alias_unix():
     HOME_PATH = os.environ["HOME"]
     BASHRC_PATH = f'{HOME_PATH}/.bashrc'
-    if platform.system() == "Darwin":
-        ZSHRC_PATH = f"{HOME_PATH}/.zshrc"
-        if os.path.isfile(BASHRC_PATH):
-            write_to_file(BASHRC_PATH)
-        if os.path.isfile(ZSHRC_PATH):
-            write_to_file(ZSHRC_PATH)
-    elif platform.system() == "Linux":
-        BASH_PROFILE_PATH = f"{HOME_PATH}/.bash_profile"
-        if os.path.isfile(BASHRC_PATH):
-            write_to_file(BASHRC_PATH)
-        elif os.path.isfile(BASH_PROFILE_PATH):
-            write_to_file(BASH_PROFILE_PATH)
+    ZSHRC_PATH = f"{HOME_PATH}/.zshrc"
+    BASH_PROFILE_PATH = f"{HOME_PATH}/.bash_profile"
+    user_os = platform.system()
+    if os.path.isfile(BASHRC_PATH):
+        write_to_file(BASHRC_PATH)
+    if user_os == "Darwin" and os.path.isfile(ZSHRC_PATH):
+        write_to_file(ZSHRC_PATH)
+    elif user_os == "Linux" and os.path.isfile(BASH_PROFILE_PATH):
+        write_to_file(BASH_PROFILE_PATH)
 
 def add_alias_windows():
     subprocess.check_call("setx ESLINT_NO_DEV_ERRORS true",

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,21 @@ import subprocess
 import platform
 import os
 
+def alias_already_exists(file_name):
+  with open(file_name, 'r') as f:
+      for line in f.readlines():
+        if "export ESLINT_NO_DEV_ERRORS=true" in line:
+          return True
+  return False
+
 def write_to_file(file_name):
-    with open(file_name, 'a') as file:
-        file.write('\n')
-        file.write("export ESLINT_NO_DEV_ERRORS=true")
-        file.write('\n')
-    print(f"\n{file_name} written! " +
-        "Open a new terminal after completing setup for changes to be in effect.")
+    if not alias_already_exists(file_name):
+        with open(file_name, 'a') as file:
+            file.write('\n')
+            file.write("export ESLINT_NO_DEV_ERRORS=true")
+            file.write('\n')
+        print(f"\n{file_name} written! " +
+            "Open a new terminal after completing setup for changes to be in effect.")
 
 def add_alias_unix():
     HOME_PATH = os.environ["HOME"]


### PR DESCRIPTION
Currently, if you run the frontend of the website with linting errors, you will receive an error screen preventing you from interacting with the website. We do not want this to happen. The fix that we have proposed is for Eslint to send warnings rather than errors. This will reserve linting errors solely for merging purposes and we do not need to fix linting errors to run the website, which could be useful for debugging.

How to test:

In order to fully test this PR, the use of three or more different OS's (Windows, MacOS, Linux) is required. 

Steps for Windows:
1. Run `python3 setup.py` in the Core-v4 directory
2. In Windows Powershell, run `Get-ChildItem Env:` This will display all the environment variables in your system.
3. If you find ESLINT_NO_DEV_ERRORS and it is set to true, then the setup ran successfully!

Steps for Linux and Mac:
1. Run `python3 setup.py` in the Core-v4 directory
2. Run `echo $ESLINT_NO_DEV_ERRORS` in a new terminal, which should return true.

Notes:
- To further check if the changes work, make a console.log in the code of any page or make any other linting error that would be caught after running the steps. If the website loads and your terminal gives Eslint warnings rather than errors, the setup was successful.
- Eslint warnings are yellow in the terminal while errors are red.
- For multiple runs of setup.py for Linux and Mac users, you may need to edit certain files to remove excess duplicate code. For Linux users, the file that you will need to edit to remove said code is either .bashrc or .bash_profile. For Mac users, the file is either .bashrc or .zshrc.