### PR TITLE
added path of /spark to point to https://spark-scesjsu.webflow.io/

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -53,6 +53,9 @@ http {
 		location / {
             proxy_pass http://webserver;
         }
+        location /spark {
+            proxy_pass https://spark-scesjsu.webflow.io;
+        }
     }
 }
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -53,7 +53,7 @@ http {
         location /spark {
             proxy_pass https://spark-scesjsu.webflow.io/;
         }
-		location / {
+	location / {
             proxy_pass http://webserver;
         }
     }

--- a/nginx.conf
+++ b/nginx.conf
@@ -50,11 +50,11 @@ http {
         location /peripheralapi {
             proxy_pass http://sce-peripheral-api;
         }
+        location /spark {
+            proxy_pass https://spark-scesjsu.webflow.io/;
+        }
 		location / {
             proxy_pass http://webserver;
-        }
-        location /spark {
-            proxy_pass https://spark-scesjsu.webflow.io;
         }
     }
 }


### PR DESCRIPTION
### How to test
- [x] make sure you have docker installed
- [x] change nginx.conf to be something like below:
```
patch -p1 <<EOF
diff --git a/nginx.conf b/nginx.conf
index cc66bdf..35c6e82 100644
--- a/nginx.conf
+++ b/nginx.conf
@@ -20,25 +20,20 @@ http {
         server sce-peripheral-api:8081;
     }
 
-    server {
-        #re-routing http to https server
-        listen 80 default_server;
-        listen [::]:80 default_server;
-        server_name _;
-        return 301 https://$host$request_uri;
-    }
+    # server {
+    #     #re-routing http to https server
+    #     listen 80 default_server;
+    #     listen [::]:80 default_server;
+    #     server_name _;
+    #     return 301 https://$host$request_uri;
+    # }
 
     # actual nginx server
     server {
 
         #443(https)
-        listen 443 ssl;
-
-        # ssl certificate
-        ssl_certificate sce_engr_sjsu_edu.cer;
-        ssl_certificate_key sce.key;
-        # TLS protocol (remember to update to the newest protocols for best security)
-        ssl_protocols TLSv1.3;
+        listen 80 default_server;
+        server_name _;
 
         #Load balancer
         location /api {
@@ -49,6 +44,9 @@ http {
         }
         location /peripheralapi {
             proxy_pass http://sce-peripheral-api;
+        }
+        location /spark {
+            proxy_pass https://spark-scesjsu.webflow.io/;
         }
         location / {
             proxy_pass http://webserver;
EOF
```
- [x] run the website with docker-compose up --build
- [x] ensure the cool spark website pops up when you go to http://localhost/spark
![image](https://user-images.githubusercontent.com/36345325/160197589-a3e09f60-0b66-4704-b796-b0fe0fb1c5ae.png)