### PR TITLE
fixing verification issues

### DIFF
--- a/api/main_endpoints/routes/Auth.js
+++ b/api/main_endpoints/routes/Auth.js
@@ -170,7 +170,7 @@ router.post('/verify', function(req, res) {
   if (!checkIfTokenSent(req)) {
     return res.sendStatus(UNAUTHORIZED);
   }
-  const isValid = checkIfTokenValid(req, membershipState.ALUMNI);
+  const isValid = checkIfTokenValid(req, membershipState.NON_MEMBER);
   if (!isValid) {
     res.sendStatus(UNAUTHORIZED);
   } else {
@@ -223,6 +223,7 @@ router.post('/validateVerificationEmail', async (req, res) => {
       }
       if (isMatch) {
         result.emailVerified = true;
+        result.accessLevel = membershipState.NON_MEMBER;
         await result
           .save()
           .then(_ => {

--- a/api/util/token-functions.js
+++ b/api/util/token-functions.js
@@ -36,7 +36,7 @@ function decodeToken(request){
  * response to the user
  * @returns {boolean} whether the user token is valid or not
  */
-function checkIfTokenValid(request, accessLevel = membershipState.MEMBER) {
+function checkIfTokenValid(request, accessLevel = membershipState.NON_MEMBER) {
   let decoded = decodeToken(request);
   let response = decoded && decoded.accessLevel >= accessLevel;
   return response;


### PR DESCRIPTION
this fixes the member verification issue where people could not log in after making an account and verifying

### How to test
- [x] create a pending user with `npm run create-user`
- [x] ensure the pending user cannot sign in
- [x] create a non-member user with `npm run create-user` again
- [x] ensure the non member user can sign in and does **not** have access to any member services