### PR TITLE
Remove HTTPS from Dev Nginx

### DIFF
--- a/nginx.dev.conf
+++ b/nginx.dev.conf
@@ -25,25 +25,9 @@ http {
         server sce-peripheral-api.core-v4_default:8081;
     }
 
-    server {
-        #re-routing http to https server
-        listen 80 default_server;
-        listen [::]:80 default_server;
-        server_name _;
-        return 301 https://$host$request_uri;
-    }
-
     # actual nginx server
     server {
-
-        #443(https)
-        listen 443 ssl;
-
-        # ssl certificate
-        ssl_certificate sce_engr_sjsu_edu.cer;
-        ssl_certificate_key sce.key;
-        # TLS protocol (remember to update to the newest protocols for best security)
-        ssl_protocols TLSv1.3;
+        listen 80 ssl;
 
         #Load balancer
         location /api {


### PR DESCRIPTION
Remove the rule for listening on https which is leftover from
incorrectly copying the file from the one used for production.