### PR TITLE
Remove token requirement for LED sign health check

### DIFF
--- a/api/peripheral_api/routes/LedSign.js
+++ b/api/peripheral_api/routes/LedSign.js
@@ -21,14 +21,6 @@ router.get('/healthCheck', async (req, res) => {
   * How these work with Quasar:
   * https://github.com/SCE-Development/Quasar/wiki/How-do-Health-Checks-Work%3F
   */
-  if (!checkIfTokenSent(req)) {
-    logger.warn('/healthCheck was requested without a token');
-    return res.sendStatus(UNAUTHORIZED);
-  }
-  if (!await verifyToken(req.body.token)) {
-    logger.warn('/healthCheck was requested with an invalid token');
-    return res.sendStatus(UNAUTHORIZED);
-  }
   if (runningInDevelopment) {
     return res.sendStatus(OK);
   }

--- a/test/api/LedSign.js
+++ b/test/api/LedSign.js
@@ -93,31 +93,18 @@ describe('LED Sign', () => {
     });
   });
 
-  describe('/POST healthCheck', () => {
-    it('Should return 400 when token is not sent', async () => {
-      const result = await test.sendGetRequest('/api/LedSign/healthCheck');
-      expect(result).to.have.status(UNAUTHORIZED);
-    });
-
-    it('Should return 400 when invalid token is sent', async () => {
-      const result = await test.sendGetRequestWithToken(token,
-        '/api/LedSign/healthCheck');
-      expect(result).to.have.status(UNAUTHORIZED);
-    });
-
+  describe('/GET healthCheck', () => {
     it('Should return 500 when the ssh tunnel is down', async () => {
       setTokenStatus(true);
       healthCheckStub.resolves(false);
-      const result = await test.sendGetRequestWithToken(token,
-        '/api/LedSign/healthCheck');
+      const result = await test.sendGetRequest('/api/LedSign/healthCheck');
       expect(result).to.have.status(SERVER_ERROR);
     });
 
     it('Should return 200 when the ssh tunnel is up', async () => {
       setTokenStatus(true);
       healthCheckStub.resolves(true);
-      const result = await test.sendGetRequestWithToken(token,
-        '/api/LedSign/healthCheck');
+      const result = await test.sendGetRequest('/api/LedSign/healthCheck');
       expect(result).to.have.status(OK);
     });
   });


### PR DESCRIPTION
We don't need it. Even if we did, the logic for checking tokens for GET requests on Core-v4 is incorrect.

- [ ] install the SCE cli from [here](https://github.com/SCE-Development/SCE-CLI/)
- [ ] run core-v4 in its entirety with `sce run c`
- [ ] sign in with an account you should have already created a while back
- [ ] navigate to http://localhost/led-sign
- [ ] ensure the healtch check works without any issues with green text rendered on the page.