### PR TITLE
add PageNumbers component for User Pagination

### DIFF
--- a/src/Pages/Overview/PageNumbers.js
+++ b/src/Pages/Overview/PageNumbers.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+function PageNumbers(props) {
+  const numberOfButtons = Math.ceil(props.count / props.usersPerPage);
+  const pageNumbers = new Array();
+  for (let i = 1; i <= numberOfButtons; i++) {
+    pageNumbers.push(i);
+  }
+  const params = props.parseQuery();
+  const currentPage = params.page ? parseInt(params.page) : 1;
+  return (
+    <nav className='user-page-numbers'>
+      <ul>
+        {pageNumbers.map(number => (
+          <button
+            key={number}
+            id={number}
+            onClick={() => props.paginate(number)}
+            className={currentPage === number
+              ? 'active-page-button' : 'nonactive-page-button'}
+          >
+            {number}
+          </button>
+        ))}
+      </ul>
+    </nav>
+  );
+}
+
+export default PageNumbers;
+

--- a/src/Pages/Overview/PageNumbers.js
+++ b/src/Pages/Overview/PageNumbers.js
@@ -6,8 +6,9 @@ function PageNumbers(props) {
   // for example, given numberOfButtons = 3:
   // this generates [0,1,2,3]
   const pageNumbers = [...Array(numberOfButtons + 1).keys()].slice(1);
-  const params = props.parseQuery();
-  const currentPage = params.page ? parseInt(params.page) : 1;
+  // const params = props.parseQuery();
+  // const currentPage = params.page ? parseInt(params.page) : 1;
+  const currentPage = props.pageNumber;
   return (
     <nav className='user-page-numbers'>
       <ul>
@@ -28,4 +29,3 @@ function PageNumbers(props) {
 }
 
 export default PageNumbers;
-

--- a/src/Pages/Overview/PageNumbers.js
+++ b/src/Pages/Overview/PageNumbers.js
@@ -2,10 +2,10 @@ import React from 'react';
 
 function PageNumbers(props) {
   const numberOfButtons = Math.ceil(props.count / props.usersPerPage);
-  const pageNumbers = new Array();
-  for (let i = 1; i <= numberOfButtons; i++) {
-    pageNumbers.push(i);
-  }
+  // this generates array of page numbers
+  // for example, given numberOfButtons = 3:
+  // this generates [0,1,2,3]
+  const pageNumbers = [...Array(numberOfButtons + 1).keys()].slice(1);
   const params = props.parseQuery();
   const currentPage = params.page ? parseInt(params.page) : 1;
   return (

--- a/src/Pages/Overview/PageNumbers.js
+++ b/src/Pages/Overview/PageNumbers.js
@@ -6,8 +6,6 @@ function PageNumbers(props) {
   // for example, given numberOfButtons = 3:
   // this generates [0,1,2,3]
   const pageNumbers = [...Array(numberOfButtons + 1).keys()].slice(1);
-  // const params = props.parseQuery();
-  // const currentPage = params.page ? parseInt(params.page) : 1;
   const currentPage = props.pageNumber;
   return (
     <nav className='user-page-numbers'>

--- a/test/frontend/PageNumbers.test.js
+++ b/test/frontend/PageNumbers.test.js
@@ -32,10 +32,12 @@ describe('<PageNumbers />', () => {
     />
   );
 
-  // should render expeced number of buttons given props.count / props.usersPerPage
+  // should render expected number of buttons given props.count
+  // and props.usersPerPage
   it('Should render 3 <button /> components', () => {
     expect(wrapper.find('button')).to.have.lengthOf(3);
   });
-  // should call paginate with correct number when button clicked, do this with evan later
+  // should call paginate with correct number when button clicked,
+  // do this with evan later
 
 });

--- a/test/frontend/PageNumbers.test.js
+++ b/test/frontend/PageNumbers.test.js
@@ -1,4 +1,3 @@
-// https://masteringjs.io/tutorials/sinon/stub-called-with
 /* global describe it */
 import 'jsdom-global/register';
 import React from 'react';
@@ -36,6 +35,17 @@ describe('<PageNumbers />', () => {
   // and props.usersPerPage
   it('Should render 3 <button /> components', () => {
     expect(wrapper.find('button')).to.have.lengthOf(3);
+  });
+
+  it('Should mark the active button with the active-page-button class', () => {
+    const buttonArray = wrapper.find('button');
+    const activeButton = buttonArray.get(0);
+    expect(activeButton.props.className).to.equal('active-page-button');
+  });
+
+  it('Should only render one button with the active-page-button class', () => {
+    const activeButtonArray = wrapper.find('.active-page-button');
+    expect(activeButtonArray).to.have.lengthOf(1);
   });
   // should call paginate with correct number when button clicked,
   // do this with evan later

--- a/test/frontend/PageNumbers.test.js
+++ b/test/frontend/PageNumbers.test.js
@@ -1,0 +1,41 @@
+// https://masteringjs.io/tutorials/sinon/stub-called-with
+/* global describe it */
+import 'jsdom-global/register';
+import React from 'react';
+import Enzyme, { mount } from 'enzyme';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import PageNumbers from '../../src/Pages/Overview/PageNumbers';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('<PageNumbers />', () => {
+
+  let pageNumber = 1;
+  let count = 10;
+  let usersPerPage = 4;
+
+  const object = {
+    paginate: (newPage) => {
+      pageNumber = newPage;
+    }
+  };
+
+  const wrapper = mount(
+    <PageNumbers
+      paginate={object.paginate}
+      pageNumber={pageNumber}
+      count={count}
+      usersPerPage={usersPerPage}
+    />
+  );
+
+  // should render expeced number of buttons given props.count / props.usersPerPage
+  it('Should render 3 <button /> components', () => {
+    expect(wrapper.find('button')).to.have.lengthOf(3);
+  });
+  // should call paginate with correct number when button clicked, do this with evan later
+
+});


### PR DESCRIPTION
Renders a certain amount of page number buttons depending on the number of users to display.

For example:
If 19 users are queried and we want to display 5 users per page, clickable page buttons (1, 2, 3, 4) would be rendered to help navigate from one page to another.

(The screenshots below display the new page numbers but the other UI changes are going to be part of another PR)

<img width="1440" alt="Screen Shot 2022-09-03 at 3 27 15 PM" src="https://user-images.githubusercontent.com/57863253/188289443-f09ce6dd-5460-4a04-bf2d-1f657c76dbd4.png">

<img width="1440" alt="Screen Shot 2022-09-03 at 3 28 51 PM" src="https://user-images.githubusercontent.com/57863253/188289466-d7162e90-30b4-4614-ade9-e44faeb6b090.png">
