### PR TITLE
Password Requirement Text Stays After Input

### DIFF
--- a/src/Pages/MembershipApplication/MembershipForm.js
+++ b/src/Pages/MembershipApplication/MembershipForm.js
@@ -124,7 +124,11 @@ export default function MembershipForm(props) {
       }
       if (password !== confirmPassword) {
         return <p
-          className='passwordRequirementInvalid'
+        const validOrInvalid = password === confirmPassword ? 'Valid' : 'Invalid';
+        const maybeDoNot =  password === confirmPassword ? '' : 'do not';
+        return <p
+          className={'passwordRequirement' + validOrInvalid}
+        >Passwords {maybeDoNot} match</p>;
         >Passwords do not match</p>;
       } else{
         return <p

--- a/src/Pages/MembershipApplication/MembershipForm.js
+++ b/src/Pages/MembershipApplication/MembershipForm.js
@@ -92,7 +92,7 @@ export default function MembershipForm(props) {
       'passwordRequirement' + (/\d/.test(password) ? 'Valid' : 'Invalid');
 
     return (
-      !checkValidPassword() && (
+      (
         <ul>
           <li id='passwordLengthRequirement' className={lengthClass}>
             8 or more characters
@@ -124,8 +124,12 @@ export default function MembershipForm(props) {
       }
       if (password !== confirmPassword) {
         return <p
-          className='unavailable application-text'
+          className='passwordRequirementInvalid'
         >Passwords do not match</p>;
+      } else{
+        return <p
+          className='passwordRequirementValid'
+        >Passwords match</p>;
       }
     }
   };

--- a/src/Pages/MembershipApplication/MembershipForm.js
+++ b/src/Pages/MembershipApplication/MembershipForm.js
@@ -123,13 +123,12 @@ export default function MembershipForm(props) {
         );
       }
       if (password !== confirmPassword) {
-        return <p
-        const validOrInvalid = password === confirmPassword ? 'Valid' : 'Invalid';
+        const validOrInvalid =
+         password === confirmPassword ? 'Valid' : 'Invalid';
         const maybeDoNot =  password === confirmPassword ? '' : 'do not';
         return <p
           className={'passwordRequirement' + validOrInvalid}
         >Passwords {maybeDoNot} match</p>;
-        >Passwords do not match</p>;
       } else{
         return <p
           className='passwordRequirementValid'


### PR DESCRIPTION
## Password Requirement Text Stays After Input
<h4> After input, password requirements dont dissapear, which made the registration page look wonky </h4>

<img width="529" alt="Screen Shot 2022-09-04 at 1 14 23 AM" src="https://user-images.githubusercontent.com/63530023/188304128-b410ec16-efe6-4290-93ce-6088a01eeb6e.png">
