### PR TITLE
Remove plugins section from .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,13 +2,5 @@
     "presets": [
         "@babel/preset-react",
         "@babel/preset-env"
-    ],
-    "plugins": [
-        [
-            "@babel/plugin-proposal-class-properties",
-            {
-                "loose": true
-            }
-        ]
     ]
 }


### PR DESCRIPTION
Removes noise from frontend tests as seen below:

![image](https://user-images.githubusercontent.com/36345325/190952551-ec6432c2-48b5-488c-949a-1103354b53f4.png)