### PR TITLE
hide all mongodb logs for dev containers

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,7 +8,7 @@ services:
       - '27017:27017'
     volumes:
       - sce_mongodb_data_dev:/data/db
-    command: 'mongod'
+    command: 'mongod --quiet --logpath /dev/null'
   sce-peripheral-api:
     container_name: sce-peripheral-api-dev
     build:


### PR DESCRIPTION
we now hide all the logs for mongodb making it easier to see debug statements bobo first pr 8)