### PR TITLE
password change bugfix

### DIFF
--- a/api/main_endpoints/routes/User.js
+++ b/api/main_endpoints/routes/User.js
@@ -185,7 +185,8 @@ router.post('/search', function(req, res) {
       lastLogin: result.lastLogin,
       membershipValidUntil: result.membershipValidUntil,
       pagesPrinted: result.pagesPrinted,
-      doorCode: result.doorCode
+      doorCode: result.doorCode,
+      _id: result._id
     };
     return res.status(OK).send(user);
   });
@@ -217,6 +218,7 @@ router.post('/edit', async (req, res) => {
   }
 
   if (!req.body._id) {
+    console.log(req.body);
     return res.sendStatus(BAD_REQUEST);
   }
 

--- a/api/main_endpoints/routes/User.js
+++ b/api/main_endpoints/routes/User.js
@@ -218,7 +218,6 @@ router.post('/edit', async (req, res) => {
   }
 
   if (!req.body._id) {
-    console.log(req.body);
     return res.sendStatus(BAD_REQUEST);
   }
 

--- a/src/Pages/Profile/MemberView/ChangePassword.js
+++ b/src/Pages/Profile/MemberView/ChangePassword.js
@@ -4,26 +4,23 @@ import './profile-modifier.css';
 
 import { editUser } from '../../../APIFunctions/User';
 
-const bcrypt = require('bcryptjs');
+
 
 export default function ChangePassword(props) {
-  const [password, setPassword] = useState('New Password');
+  const [password, setPassword] = useState('');
   const [confirmPass, setConfirmPass] = useState('Confirming New Password');
-  const [user, setUser] = useState('');
   const [toggle, setToggle] = useState(true);
 
   async function changePassword() {
-    const salt = bcrypt.genSaltSync(10);
-    const hashedPassword = password.trim() === '' ? user.password :
-      bcrypt.hashSync(password, salt);
+
 
     if (password === confirmPass) {
       const apiResponse = await editUser(
         {
-          ...user,
-          password: hashedPassword
+          ...props.user,
+          password
         },
-        user.token
+        props.user.token
       );
 
       if (!apiResponse.error) {
@@ -58,7 +55,6 @@ export default function ChangePassword(props) {
           <Input
             id="new-password"
             onChange={(e) => {
-              setUser(props.user);
               setPassword(e.target.value);
             }}
             type="password"
@@ -71,7 +67,6 @@ export default function ChangePassword(props) {
           <Input
             id="confirm-password"
             onChange={(e) => {
-              setUser(props.user);
               setConfirmPass(e.target.value);
             }}
             type="password"


### PR DESCRIPTION
removed unnecessary bcrypt (already encrypts over https), which was also bugging out password change 
changed useState of password to '' instead of 'New Password' 
removed redudant user const (just use props.user)