### PR TITLE
Remove Profile Image

### DIFF
--- a/src/Components/Navbar/UserNavbar.js
+++ b/src/Components/Navbar/UserNavbar.js
@@ -85,17 +85,7 @@ export default function UserNavBar(props) {
               {props.authenticated && props.user ? (
                 <div className='dropdown-submenu drp-item'>
                   <DropdownItem className='drp-item' id='btndrp-text'>
-                    <svg className='profile-image' viewBox='0 0 24 24'>
-                      <path
-                        fill='gray'
-                        d='M12,19.2C9.5,19.2 7.29,17.92 6,16C6.03,14 10,
-                          12.9 12,12.9C14,12.9 17.97,14 18,16C16.71,
-                          17.92 14.5,19.2 12,19.2M12,5A3,3 0 0,1 15,8A3,
-                          3 0 0,1 12,11A3,3 0 0,1 9,8A3,3 0 0,1 12,5M12,
-                          2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,
-                          0 22,12C22,6.47 17.5,2 12,2Z'
-                      />
-                    </svg>
+                    
                     {props.user.firstName}
                   </DropdownItem>
                   <DropdownMenu right className='drp-menu'>
@@ -153,17 +143,6 @@ export default function UserNavBar(props) {
                 <div className='profile'>
                   <UncontrolledDropdown nav inNavbar>
                     <DropdownToggle className='text-white' nav caret>
-                      <svg className='profile-image' viewBox='0 0 24 24'>
-                        <path
-                          fill='white'
-                          d='M12,19.2C9.5,19.2 7.29,17.92 6,16C6.03,14 10,
-                          12.9 12,12.9C14,12.9 17.97,14 18,16C16.71,
-                          17.92 14.5,19.2 12,19.2M12,5A3,3 0 0,1 15,
-                          8A3,3 0 0,1 12,11A3,3 0 0,1 9,8A3,3 0 0,1 12,
-                          5M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,
-                          10 0 0,0 22,12C22,6.47 17.5,2 12,2Z'
-                        />
-                      </svg>
                       {props.user.firstName}
                     </DropdownToggle>
                     <DropdownMenu right>

--- a/src/Components/Navbar/navbar.css
+++ b/src/Components/Navbar/navbar.css
@@ -115,11 +115,6 @@
   right:46px;
 }
 
-.profile-image {
-  width: 30px;
-  height: 30px;
-}
-
 #btndrp-text {
   color: gray;
   font-weight: bold;


### PR DESCRIPTION
Remove Profile Image from nav bar
<img width="1277" alt="image" src="https://user-images.githubusercontent.com/63530023/196549688-36f23063-cc21-4d7e-b719-b015614dee15.png">

Before it was 
<img width="1276" alt="image" src="https://user-images.githubusercontent.com/63530023/196549768-451948ba-9b99-4177-86dd-0684c1651cbc.png">

Profile Image had no use, no one else can see them, and no way to set them. Removed.
