### PR TITLE
Add sorting to users table

### DIFF
--- a/api/main_endpoints/routes/User.js
+++ b/api/main_endpoints/routes/User.js
@@ -187,8 +187,8 @@ router.post('/users', async function(req, res) {
     desc: -1,
     asc: 1,
     default: -1
-  }
-  const sortOrder = orderToInteger[req.query.order] || orderToInteger.default
+  };
+  const sortOrder = orderToInteger[req.query.order] || orderToInteger.default;
 
   // make sure that the page we want to see is 0 by default
   // and avoid negative page numbers

--- a/api/main_endpoints/routes/User.js
+++ b/api/main_endpoints/routes/User.js
@@ -181,13 +181,16 @@ router.post('/users', async function(req, res) {
     };
   }
 
+  const sortColumn = req.query.sort || 'joinDate';
+  const sortOrder = req.query.order === 'desc' ? -1 : (req.query.order === 'asc' ? 1 : -1);
+
   // make sure that the page we want to see is 0 by default
   // and avoid negative page numbers
   let skip = Math.max(Number(req.body.page) || 0, 0);
   skip *= ROWS_PER_PAGE;
   const total = await User.count(maybeOr);
   User.find(maybeOr, { password: 0, }, { skip, limit: ROWS_PER_PAGE, })
-    .sort({ joinDate: -1 })
+    .sort({ [sortColumn] : sortOrder })
     .then(items => {
       res.status(OK).send({ items, total, rowsPerPage: ROWS_PER_PAGE, });
     })

--- a/api/main_endpoints/routes/User.js
+++ b/api/main_endpoints/routes/User.js
@@ -182,7 +182,13 @@ router.post('/users', async function(req, res) {
   }
 
   const sortColumn = req.query.sort || 'joinDate';
-  const sortOrder = req.query.order === 'desc' ? -1 : (req.query.order === 'asc' ? 1 : -1);
+
+  const orderToInteger = {
+    desc: -1,
+    asc: 1,
+    default: -1
+  }
+  const sortOrder = orderToInteger[req.query.order] || orderToInteger.default
 
   // make sure that the page we want to see is 0 by default
   // and avoid negative page numbers

--- a/src/APIFunctions/User.js
+++ b/src/APIFunctions/User.js
@@ -11,11 +11,27 @@ let GENERAL_API_URL = process.env.REACT_APP_GENERAL_API_URL
  * @returns {UserApiResponse} Containing any error information or the array of
  * users.
  */
-export async function getAllUsers(token, query = null, page = null, sortColumn = null, sortOrder = null) {
+export async function getAllUsers({
+  token,
+  query = null,
+  page = null,
+  sortColumn = null,
+  sortOrder = null,
+}) {
+  const url = new URL(GENERAL_API_URL + '/User/users')
+
+  if (sortColumn) {
+    url.searchParams.set('sort', sortColumn);
+  }
+  
+  if (sortOrder) {
+    url.searchParams.set('order', sortOrder);
+  }
+
   let status = new UserApiResponse();
   await axios
     // get all user!
-    .post(GENERAL_API_URL + '/User/users' + `?sort=${sortColumn}&order=${sortOrder}`, {
+    .post(url.href, {
       token,
       query,
       page,

--- a/src/APIFunctions/User.js
+++ b/src/APIFunctions/User.js
@@ -18,12 +18,12 @@ export async function getAllUsers({
   sortColumn = null,
   sortOrder = null,
 }) {
-  const url = new URL(GENERAL_API_URL + '/User/users')
+  const url = new URL(GENERAL_API_URL + '/User/users');
 
   if (sortColumn) {
     url.searchParams.set('sort', sortColumn);
   }
-  
+
   if (sortOrder) {
     url.searchParams.set('order', sortOrder);
   }

--- a/src/APIFunctions/User.js
+++ b/src/APIFunctions/User.js
@@ -11,11 +11,11 @@ let GENERAL_API_URL = process.env.REACT_APP_GENERAL_API_URL
  * @returns {UserApiResponse} Containing any error information or the array of
  * users.
  */
-export async function getAllUsers(token, query = null, page = null) {
+export async function getAllUsers(token, query = null, page = null, sortColumn = null, sortOrder = null) {
   let status = new UserApiResponse();
   await axios
     // get all user!
-    .post(GENERAL_API_URL + '/User/users', {
+    .post(GENERAL_API_URL + '/User/users' + `?sort=${sortColumn}&order=${sortOrder}`, {
       token,
       query,
       page,

--- a/src/Pages/Overview/Overview.js
+++ b/src/Pages/Overview/Overview.js
@@ -68,7 +68,7 @@ export default function Overview(props) {
       page: page,
       sortColumn: sortColumn,
       sortOrder: sortOrder
-  });
+    });
     if (!apiResponse.error) {
       setUsers(apiResponse.responseData.items);
       setTotal(apiResponse.responseData.total);

--- a/src/Pages/Overview/Overview.js
+++ b/src/Pages/Overview/Overview.js
@@ -19,14 +19,8 @@ export default function Overview(props) {
   const [queryResult, setQueryResult] = useState([]);
   const [rowsPerPage, setRowsPerPage] = useState(0);
   const [query, setQuery] = useState('');
-  const [sortColumn, setSortColumn] = useState('joinDate');
-  const [sortOrder, setSortOrder] = useState('desc');
-  const [columnStates, setColumnStates] = useState({
-    'Name/Email': 'unused',
-    'Printing': 'unused',
-    'Verified': 'unused',
-    'Membership': 'unused'
-  });
+  const [currentSortColumn, setCurrentSortColumn] = useState('joinDate');
+  const [currentSortOrder, setCurrentSortOrder] = useState('desc');
   // const [toggle, setToggle] = useState(false);
   // const [currentQueryType, setCurrentQueryType] = useState('All');
   // const queryTypes = ['All', 'Pending', 'Officer', 'Admin', 'Alumni'];
@@ -62,6 +56,8 @@ export default function Overview(props) {
 
   async function callDatabase() {
     setLoading(true);
+    const sortColumn = currentSortOrder === 'none' ? 'joinDate' : currentSortColumn;
+    const sortOrder = currentSortOrder === 'none' ? 'desc' : currentSortOrder;
     const apiResponse = await getAllUsers({
       token: props.user.token,
       query: query,
@@ -79,7 +75,7 @@ export default function Overview(props) {
 
   useEffect(() => {
     callDatabase();
-  }, [page, sortColumn, sortOrder]);
+  }, [page, currentSortColumn, currentSortOrder]);
 
   useEffect(() => {
 
@@ -100,35 +96,17 @@ export default function Overview(props) {
   }, [page, rowsPerPage, users, total]);
 
   function handleSortUsers(columnName) {
-    const columnMap = {
-      'Name/Email': 'email',
-      'Printing': 'pagesPrinted',
-      'Verified': 'emailVerified',
-      'Membership': 'accessLevel'
-    };
-
-    let newColumnStates = {...columnStates};
-    if (newColumnStates[columnName] === 'desc') {
-      newColumnStates[columnName] = 'asc';
-    } else if (newColumnStates[columnName] === 'asc') {
-      newColumnStates[columnName] = 'unused';
-    } else {
-      newColumnStates[columnName] = 'desc';
-    }
-
-    for (const key in newColumnStates) {
-      if (key !== columnName) {
-        newColumnStates[key] = 'unused';
+    if(currentSortColumn === columnName) {
+      if (currentSortOrder === 'asc') {
+        setCurrentSortOrder('desc');
+      } else if (currentSortOrder === 'desc') {
+        setCurrentSortOrder('none');
+      } else {
+        setCurrentSortOrder('asc');
       }
-    }
-    setColumnStates(newColumnStates);
-
-    if (newColumnStates[columnName] === 'unused') {
-      setSortColumn('joinDate');
-      setSortOrder('desc');
     } else {
-      setSortColumn(columnMap[columnName]);
-      setSortOrder(newColumnStates[columnName]);
+      setCurrentSortColumn(columnName);
+      setCurrentSortOrder('asc');
     }
   }
 
@@ -266,17 +244,17 @@ export default function Overview(props) {
             <thead>
               <tr>
                 {[
-                  { title: 'Name/Email', className: 'text-base text-white/70' },
-                  { title: 'Printing', className: 'text-base text-white/70 hidden text-center md:table-cell' },
-                  { title: 'Verified', className: 'text-base text-white/70 text-center hidden sm:table-cell' },
-                  { title: 'Membership', className: 'text-base text-white/70 hidden text-center sm:table-cell' },
-                  { title: 'Delete', className: 'text-base text-white/70 text-center' },
-                ].map(({ title, className }) => (
+                  { title: 'Name/Email', className: 'text-base text-white/70', columnName: 'email'},
+                  { title: 'Printing', className: 'text-base text-white/70 hidden text-center md:table-cell', columnName: 'pagesPrinted'},
+                  { title: 'Verified', className: 'text-base text-white/70 text-center hidden sm:table-cell', columnName: 'emailVerified'},
+                  { title: 'Membership', className: 'text-base text-white/70 hidden text-center sm:table-cell', columnName: 'accessLevel'},
+                  { title: 'Delete', className: 'text-base text-white/70 text-center', columnName: 'delete'},
+                ].map(({ title, className, columnName }) => (
                   <th
                     className={`${className}`}
                     key={title}
                   >
-                    <button onClick={() => handleSortUsers(title)}>{title}</button>
+                    <button onClick={() => handleSortUsers(columnName)}>{title}</button>
                   </th>
                 ))}
               </tr>

--- a/src/Pages/Overview/Overview.js
+++ b/src/Pages/Overview/Overview.js
@@ -96,6 +96,9 @@ export default function Overview(props) {
   }, [page, rowsPerPage, users, total]);
 
   function handleSortUsers(columnName) {
+    if (columnName == null) {
+      return;
+    }
     if(currentSortColumn === columnName) {
       if (currentSortOrder === 'asc') {
         setCurrentSortOrder('desc');
@@ -248,8 +251,8 @@ export default function Overview(props) {
                   { title: 'Printing', className: 'text-base text-white/70 hidden text-center md:table-cell', columnName: 'pagesPrinted'},
                   { title: 'Verified', className: 'text-base text-white/70 text-center hidden sm:table-cell', columnName: 'emailVerified'},
                   { title: 'Membership', className: 'text-base text-white/70 hidden text-center sm:table-cell', columnName: 'accessLevel'},
-                  { title: 'Delete', className: 'text-base text-white/70 text-center', columnName: 'delete'},
-                ].map(({ title, className, columnName }) => (
+                  { title: 'Delete', className: 'text-base text-white/70 text-center'},
+                ].map(({ title, className, columnName = null}) => (
                   <th
                     className={`${className}`}
                     key={title}

--- a/src/Pages/Overview/Overview.js
+++ b/src/Pages/Overview/Overview.js
@@ -62,7 +62,13 @@ export default function Overview(props) {
 
   async function callDatabase() {
     setLoading(true);
-    const apiResponse = await getAllUsers(props.user.token, query, page, sortColumn, sortOrder);
+    const apiResponse = await getAllUsers({
+      token: props.user.token,
+      query: query,
+      page: page,
+      sortColumn: sortColumn,
+      sortOrder: sortOrder
+  });
     if (!apiResponse.error) {
       setUsers(apiResponse.responseData.items);
       setTotal(apiResponse.responseData.total);

--- a/src/Pages/Overview/Overview.js
+++ b/src/Pages/Overview/Overview.js
@@ -19,6 +19,8 @@ export default function Overview(props) {
   const [queryResult, setQueryResult] = useState([]);
   const [rowsPerPage, setRowsPerPage] = useState(0);
   const [query, setQuery] = useState('');
+  const [sortedUsers, setSortedUsers] = useState([]);
+  const [sortingColumn, setSortingColumn] = useState(null);
   // const [toggle, setToggle] = useState(false);
   // const [currentQueryType, setCurrentQueryType] = useState('All');
   // const queryTypes = ['All', 'Pending', 'Officer', 'Admin', 'Alumni'];
@@ -84,6 +86,28 @@ export default function Overview(props) {
       </>
     );
   }, [page, rowsPerPage, users, total]);
+
+  useEffect(() => {
+    if (sortingColumn) { 
+      const sortedUsers = sortUsers(users, sortingColumn); 
+      setSortedUsers(sortedUsers);
+    }
+  }, [sortingColumn, users]);
+
+    function sortUsers(users, columnName) { 
+      switch(columnName) { 
+        case 'Name/Email':
+          return [...users].sort((a, b) => a.email.localeCompare(b.email));
+        case 'Printing':
+          return [...users].sort((a, b) => b.pagesPrinted - a.pagesPrinted); 
+        case 'Verified':
+          return [...users].sort((a, b) => b.emailVerified - a.emailVerified);
+        case 'Membership':
+          return [...users].sort((a,b) => b.accessLevel - a.accessLevel); 
+        default:
+          return users;
+      }
+    }
 
   // function filterUserByAccessLevel(accessLevel) {
   //   switch (accessLevel) {
@@ -229,13 +253,13 @@ export default function Overview(props) {
                     className={`${className}`}
                     key={title}
                   >
-                    {title}
+                    <button onClick={() => setSortingColumn(title)}>{title}</button>
                   </th>
                 ))}
               </tr>
             </thead>
             <tbody>
-              {users.map((user) => (
+              {(sortingColumn ? sortedUsers : users).map((user) => (
                 <tr className='break-all !rounded md:break-keep hover:bg-white/10' key={user.email}>
                   <td className=''>
                     <a className='link link-hover link-info' target="_blank" rel="noopener noreferrer" href={`/user/edit/${user._id}`}>

--- a/src/Pages/Overview/Overview.js
+++ b/src/Pages/Overview/Overview.js
@@ -21,6 +21,12 @@ export default function Overview(props) {
   const [query, setQuery] = useState('');
   const [sortColumn, setSortColumn] = useState('joinDate');
   const [sortOrder, setSortOrder] = useState('desc');
+  const [columnStates, setColumnStates] = useState({
+    'Name/Email': 'unused',
+    'Printing': 'unused',
+    'Verified': 'unused',
+    'Membership': 'unused'
+  });
   // const [toggle, setToggle] = useState(false);
   // const [currentQueryType, setCurrentQueryType] = useState('All');
   // const queryTypes = ['All', 'Pending', 'Officer', 'Admin', 'Alumni'];
@@ -67,7 +73,7 @@ export default function Overview(props) {
 
   useEffect(() => {
     callDatabase();
-  }, [page, sortColumn]);
+  }, [page, sortColumn, sortOrder]);
 
   useEffect(() => {
 
@@ -88,21 +94,35 @@ export default function Overview(props) {
   }, [page, rowsPerPage, users, total]);
 
   function handleSortUsers(columnName) {
-    switch(columnName) {
-    case 'Name/Email':
-      setSortColumn('email');
-      break;
-    case 'Printing':
-      setSortColumn('pagesPrinted');
-      break;
-    case 'Verified':
-      setSortColumn('emailVerified');
-      break;
-    case 'Membership':
-      setSortColumn('accessLevel');
-      break;
-    default:
-      break;
+    const columnMap = {
+      'Name/Email': 'email',
+      'Printing': 'pagesPrinted',
+      'Verified': 'emailVerified',
+      'Membership': 'accessLevel'
+    };
+
+    let newColumnStates = {...columnStates};
+    if (newColumnStates[columnName] === 'desc') {
+      newColumnStates[columnName] = 'asc';
+    } else if (newColumnStates[columnName] === 'asc') {
+      newColumnStates[columnName] = 'unused';
+    } else {
+      newColumnStates[columnName] = 'desc';
+    }
+
+    for (const key in newColumnStates) {
+      if (key !== columnName) {
+        newColumnStates[key] = 'unused';
+      }
+    }
+    setColumnStates(newColumnStates);
+
+    if (newColumnStates[columnName] === 'unused') {
+      setSortColumn('joinDate');
+      setSortOrder('desc');
+    } else {
+      setSortColumn(columnMap[columnName]);
+      setSortOrder(newColumnStates[columnName]);
     }
   }
 

--- a/src/Pages/Overview/Overview.js
+++ b/src/Pages/Overview/Overview.js
@@ -19,8 +19,8 @@ export default function Overview(props) {
   const [queryResult, setQueryResult] = useState([]);
   const [rowsPerPage, setRowsPerPage] = useState(0);
   const [query, setQuery] = useState('');
-  const [sortedUsers, setSortedUsers] = useState([]);
-  const [sortingColumn, setSortingColumn] = useState(null);
+  const [sortColumn, setSortColumn] = useState('joinDate');
+  const [sortOrder, setSortOrder] = useState('desc');
   // const [toggle, setToggle] = useState(false);
   // const [currentQueryType, setCurrentQueryType] = useState('All');
   // const queryTypes = ['All', 'Pending', 'Officer', 'Admin', 'Alumni'];
@@ -56,7 +56,7 @@ export default function Overview(props) {
 
   async function callDatabase() {
     setLoading(true);
-    const apiResponse = await getAllUsers(props.user.token, query, page);
+    const apiResponse = await getAllUsers(props.user.token, query, page, sortColumn, sortOrder);
     if (!apiResponse.error) {
       setUsers(apiResponse.responseData.items);
       setTotal(apiResponse.responseData.total);
@@ -67,7 +67,7 @@ export default function Overview(props) {
 
   useEffect(() => {
     callDatabase();
-  }, [page]);
+  }, [page, sortColumn]);
 
   useEffect(() => {
 
@@ -87,27 +87,24 @@ export default function Overview(props) {
     );
   }, [page, rowsPerPage, users, total]);
 
-  useEffect(() => {
-    if (sortingColumn) { 
-      const sortedUsers = sortUsers(users, sortingColumn); 
-      setSortedUsers(sortedUsers);
+  function handleSortUsers(columnName) {
+    switch(columnName) {
+    case 'Name/Email':
+      setSortColumn('email');
+      break;
+    case 'Printing':
+      setSortColumn('pagesPrinted');
+      break;
+    case 'Verified':
+      setSortColumn('emailVerified');
+      break;
+    case 'Membership':
+      setSortColumn('accessLevel');
+      break;
+    default:
+      break;
     }
-  }, [sortingColumn, users]);
-
-    function sortUsers(users, columnName) { 
-      switch(columnName) { 
-        case 'Name/Email':
-          return [...users].sort((a, b) => a.email.localeCompare(b.email));
-        case 'Printing':
-          return [...users].sort((a, b) => b.pagesPrinted - a.pagesPrinted); 
-        case 'Verified':
-          return [...users].sort((a, b) => b.emailVerified - a.emailVerified);
-        case 'Membership':
-          return [...users].sort((a,b) => b.accessLevel - a.accessLevel); 
-        default:
-          return users;
-      }
-    }
+  }
 
   // function filterUserByAccessLevel(accessLevel) {
   //   switch (accessLevel) {
@@ -253,13 +250,13 @@ export default function Overview(props) {
                     className={`${className}`}
                     key={title}
                   >
-                    <button onClick={() => setSortingColumn(title)}>{title}</button>
+                    <button onClick={() => handleSortUsers(title)}>{title}</button>
                   </th>
                 ))}
               </tr>
             </thead>
             <tbody>
-              {(sortingColumn ? sortedUsers : users).map((user) => (
+              {users.map((user) => (
                 <tr className='break-all !rounded md:break-keep hover:bg-white/10' key={user.email}>
                   <td className=''>
                     <a className='link link-hover link-info' target="_blank" rel="noopener noreferrer" href={`/user/edit/${user._id}`}>

--- a/src/Pages/Overview/Overview.js
+++ b/src/Pages/Overview/Overview.js
@@ -96,7 +96,7 @@ export default function Overview(props) {
   }, [page, rowsPerPage, users, total]);
 
   function handleSortUsers(columnName) {
-    if (columnName == null) {
+    if (columnName === null) {
       return;
     }
     if(currentSortColumn === columnName) {


### PR DESCRIPTION
Added user sorting for issue #1389 
Sorts based on column name with buttons for each column. There are 3 states 'desc', 'asc', and 'unused', and it defaults to sorting by joinDate in descending order.

- Altered /routes/User to grab the queries and sort by the query
- Altered /APIFunctions/User to include sort and order parameters in request
- Altered /Overview to contain states for column, order, and states.