### PR TITLE
Add Prometheus metrics to Messaging API

### DIFF
--- a/api/main_endpoints/routes/Messages.js
+++ b/api/main_endpoints/routes/Messages.js
@@ -10,18 +10,61 @@ const router = express.Router();
 const bodyParser = require('body-parser');
 const User = require('../models/User.js');
 const logger = require('../../util/logger');
+const client = require('prom-client');
 const { decodeToken, decodeTokenFromBodyOrQuery } = require('../util/token-functions.js');
 
 
 router.use(bodyParser.json());
+
+// all data collected about server activity
+let register = new client.Registry();
+
+// all the metrics for the messages api
+const currentRoomsOpen = new client.Gauge({
+  name: 'current_rooms_open',
+  help: 'Number of chatrooms currently open'
+});
+
+const totalMessagesSent = new client.Counter({
+  name: 'total_messages_sent',
+  help: 'Total number of messages sent'
+});
+
+const totalRoomsOpened = new client.Counter({
+  name: 'total_rooms_opened',
+  help: 'Total rooms opened'
+});
+
+const currentConnectionsOpen = new client.Gauge({
+  name: 'current_connections_open',
+  help: 'Total number of connections open'
+});
+
+const totalChatMessagesPerChatRoom = new client.Counter({
+  name: 'total_chat_messages_per_chatroom',
+  help: 'Total number of messages sent per chatroom',
+  labelNames: ['id']
+});
+
+// register all the metrics for prometheus
+register.registerMetric(currentRoomsOpen);
+register.registerMetric(totalMessagesSent);
+register.registerMetric(currentConnectionsOpen);
+register.registerMetric(totalChatMessagesPerChatRoom);
+register.registerMetric(totalRoomsOpened);
+
+// set label for messages api prometheus label
+register.setDefaultLabels({
+  app: 'messages-api'
+});
+
+client.collectDefaultMetrics({ register });
 
 const clients = {};
 const numberOfConnections = {};
 const lastMessageSent = {};
 
 const writeMessage = ((roomId, message) => {
-
-  const currentTimestamp = new Date();
 
   const messageObj = {
     timestamp: Date.now(),
@@ -33,6 +76,12 @@ const writeMessage = ((roomId, message) => {
   }
 
   lastMessageSent[roomId] = JSON.stringify(messageObj);
+
+  // increase the total messages sent counter
+  totalMessagesSent.inc();
+
+  // increase the total amount of messages sent per chatroom counter
+  totalChatMessagesPerChatRoom.labels(roomId).inc();
 });
 
 router.post('/send', async (req, res) => {
@@ -180,17 +229,30 @@ router.get('/listen', async (req, res) => {
 
       if(!clients[id]){
         clients[id] = [];
+
+        // increase total amount of rooms opened
+        totalRoomsOpened.inc();
+
+        // increase the current rooms open gauge
+        currentRoomsOpen.inc();
       }
+
+      // add connection to the connections open gauge
+      currentConnectionsOpen.inc();
 
       clients[id].push(res);
 
       req.on('close', () => {
         if(clients[id]){
+          currentConnectionsOpen.dec();
           clients[id] = clients[id].filter(client => client !== res);
         }
         if(clients[id].length === 0){
           delete clients[id];
           delete lastMessageSent[id];
+
+          // if no more clients in the room, decrement the current rooms open gauge
+          currentRoomsOpen.dec();
         }
         numberOfConnections[_id] -= 1;
       });
@@ -199,6 +261,13 @@ router.get('/listen', async (req, res) => {
     logger.error('Error in /listen: ', error);
     res.sendStatus(SERVER_ERROR);
   }
+});
+
+
+// to get prometheus metrics
+router.get('/metrics', async (req, res) => {
+  res.setHeader('Content-Type', register.contentType);
+  res.end(await register.metrics());
 });
 
 // heartbeat mechanism to bypass NGINX timeout

--- a/api/util/metrics.js
+++ b/api/util/metrics.js
@@ -26,32 +26,32 @@ class MetricsHandler {
 	});
 
 	currentRoomsOpen = new client.Gauge({
-		name: 'current_rooms_open',
-		help: 'Number of chatrooms currently open'
-	  });
-	
-	  totalMessagesSent = new client.Counter({
-		name: 'total_messages_sent',
-		help: 'Total number of messages sent'
-	  });
-	
-	  totalRoomsOpened = new client.Counter({
-		name: 'total_rooms_opened',
-		help: 'Total rooms opened'
-	  });
-	
-	  currentConnectionsOpen = new client.Gauge({
-		name: 'current_connections_open',
-		help: 'Total number of connections open'
-	  });
-	
-	  totalChatMessagesPerChatRoom = new client.Counter({
-		name: 'total_chat_messages_per_chatroom',
-		help: 'Total number of messages sent per chatroom',
-		labelNames: ['id']
+	  name: 'current_rooms_open',
+	  help: 'Number of chatrooms currently open'
 	  });
 
-	constructor() {
+	  totalMessagesSent = new client.Counter({
+	    name: 'total_messages_sent',
+	    help: 'Total number of messages sent'
+	  });
+
+	  totalRoomsOpened = new client.Counter({
+	    name: 'total_rooms_opened',
+	    help: 'Total rooms opened'
+	  });
+
+	  currentConnectionsOpen = new client.Gauge({
+	    name: 'current_connections_open',
+	    help: 'Total number of connections open'
+	  });
+
+	  totalChatMessagesPerChatRoom = new client.Counter({
+	    name: 'total_chat_messages_per_chatroom',
+	    help: 'Total number of messages sent per chatroom',
+	    labelNames: ['id']
+	  });
+
+	  constructor() {
 	  register.setDefaultLabels({
 	    app: 'sce-core',
 	  });
@@ -60,7 +60,7 @@ class MetricsHandler {
 	  Object.keys(this).forEach(metric => {
 	    register.registerMetric(this[metric]);
 	  });
-	}
+	  }
 }
 
 module.exports = {

--- a/api/util/metrics.js
+++ b/api/util/metrics.js
@@ -25,6 +25,32 @@ class MetricsHandler {
 	  labelNames: ['type'],
 	});
 
+	currentRoomsOpen = new client.Gauge({
+		name: 'current_rooms_open',
+		help: 'Number of chatrooms currently open'
+	  });
+	
+	  totalMessagesSent = new client.Counter({
+		name: 'total_messages_sent',
+		help: 'Total number of messages sent'
+	  });
+	
+	  totalRoomsOpened = new client.Counter({
+		name: 'total_rooms_opened',
+		help: 'Total rooms opened'
+	  });
+	
+	  currentConnectionsOpen = new client.Gauge({
+		name: 'current_connections_open',
+		help: 'Total number of connections open'
+	  });
+	
+	  totalChatMessagesPerChatRoom = new client.Counter({
+		name: 'total_chat_messages_per_chatroom',
+		help: 'Total number of messages sent per chatroom',
+		labelNames: ['id']
+	  });
+
 	constructor() {
 	  register.setDefaultLabels({
 	    app: 'sce-core',

--- a/api/util/metrics.js
+++ b/api/util/metrics.js
@@ -25,24 +25,15 @@ class MetricsHandler {
 	  labelNames: ['type'],
 	});
 
-	currentRoomsOpen = new client.Gauge({
-	  name: 'current_rooms_open',
-	  help: 'Number of chatrooms currently open'
-	  });
-
 	  totalMessagesSent = new client.Counter({
 	    name: 'total_messages_sent',
 	    help: 'Total number of messages sent'
 	  });
 
-	  totalRoomsOpened = new client.Counter({
-	    name: 'total_rooms_opened',
-	    help: 'Total rooms opened'
-	  });
-
 	  currentConnectionsOpen = new client.Gauge({
 	    name: 'current_connections_open',
-	    help: 'Total number of connections open'
+	    help: 'Total number of connections open',
+	    labelNames: ['id']
 	  });
 
 	  totalChatMessagesPerChatRoom = new client.Counter({


### PR DESCRIPTION
- Initialized Prometheus metrics for Messaging API 
- Added the following metrics that Prometheus will monitor: current_rooms_open, total_messages_sent, current_connections_open, total_chat_messages_per_chatroom, and total_rooms_opened