### PR TITLE
Add multiline messages to Messaging API

### DIFF
--- a/api/main_endpoints/routes/Messages.js
+++ b/api/main_endpoints/routes/Messages.js
@@ -19,13 +19,14 @@ const clients = {};
 const numberOfConnections = {};
 const lastMessageSent = {};
 
-const writeMessage = ((roomId, message) => {
+const writeMessage = ((roomId, message, username) => {
 
   const currentTimestamp = new Date();
 
   const messageObj = {
     timestamp: Date.now(),
     message,
+    username
   };
 
   if (clients[roomId]) {
@@ -74,7 +75,7 @@ router.post('/send', async (req, res) => {
         return;
       }
       if (result) {
-        writeMessage(id, `${result.firstName}: ${message}`);
+        writeMessage(id, `${message}`, `${result.firstName}:`);
         return res.json({status: 'Message sent'});
       }
       return res.sendStatus(UNAUTHORIZED);

--- a/src/Pages/Messaging/Messaging.js
+++ b/src/Pages/Messaging/Messaging.js
@@ -154,8 +154,11 @@ function Feed(props) {
       <div id="messages" className="border border-gray-300 p-3 h-96 overflow-y-auto bg-gray-100 w-2/3 rounded-lg mt-3">
         {messages.map((message, index) => (
           <div key={index} className="p-2 mb-1 border-b border-gray-200 flex items-center">
-            <div className="text-gray-700 grow">{message['message']}</div>
-            <div className="text-gray-500 text-xs">
+            <div className='flex flex-row'>
+              <div className="text-gray-700 grow" >{message['username']}</div>
+              <div className="text-gray-700 grow ml-1 whitespace-pre-wrap">{message['message']}</div>
+            </div>
+            <div className="text-gray-500 text-xs ml-auto">
               {
                 new Date(message['timestamp']).toLocaleString(
                   [],


### PR DESCRIPTION
- Change the JSON messageObj to have username attribute so we can create two separate div for message and user (to enable indentation when add a new line)
  - Before:

  ```
  user: line 1
  line2
  ```
  
   - After:
  ```
  user: line 1
        line 2
  ```
 - Use whitespace-pre-wrap to have the feed display '\n' as new line
