### PR TITLE
use originalUrl field in prometheus route label for api requests

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,7 +24,7 @@ jobs:
     - run: python setup.py
     - name: cache frontend dependencies
       id: frontend-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ./node_modules
         key: modules-${{ hashFiles('package-lock.json') }}
@@ -52,7 +52,7 @@ jobs:
     # split api and frontend code completely
     - name: cache frontend dependencies
       id: frontend-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ./node_modules
         key: modules-${{ hashFiles('package-lock.json') }}
@@ -61,7 +61,7 @@ jobs:
       run: npm ci --ignore-scripts
     - name: cache backend dependencies
       id: cache-api
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ./api/node_modules
         key: modules-${{ hashFiles('api/package-lock.json') }}
@@ -85,7 +85,7 @@ jobs:
     # the frontend dependencies include eslint
     - name: cache frontend dependencies
       id: frontend-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ./node_modules
         key: modules-${{ hashFiles('package-lock.json') }}
@@ -109,7 +109,7 @@ jobs:
     # the frontend dependencies include eslint
     - name: cache frontend dependencies
       id: frontend-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ./node_modules
         key: modules-${{ hashFiles('package-lock.json') }}

--- a/api/util/SceHttpServer.js
+++ b/api/util/SceHttpServer.js
@@ -58,10 +58,10 @@ class SceHttpServer {
   registerMetricsMiddleware() {
     this.app.use((req, res, next) => {
       res.on('finish', () => {
-        const route = req.route ? req.route.path : req.path;
         MetricsHandler.endpointHits.inc({
           method: req.method,
-          route: route,
+          // for example "/api/Auth/verify"
+          route: req.originalUrl,
           statusCode: res.statusCode,
         });
       });


### PR DESCRIPTION
now we get the full path of the request, like
```
sce-main-endpoints      | /api/Auth/login
sce-main-endpoints      | /api/User/edit
sce-main-endpoints      | /api/Advertisement/
sce-main-endpoints      | /api/Auth/verify
sce-main-endpoints      | /api/Advertisement/
```

before it was below, which doesnt give much context as we dont know what the full path of the request was

```
sce-main-endpoints      | login
sce-main-endpoints      | edit
sce-main-endpoints      | /
sce-main-endpoints      | verify
sce-main-endpoints      | /
```