### PR TITLE
use req._parsedUrl.pathname in prometheus route label for api requests

### DIFF
--- a/api/util/SceHttpServer.js
+++ b/api/util/SceHttpServer.js
@@ -57,11 +57,12 @@ class SceHttpServer {
 
   registerMetricsMiddleware() {
     this.app.use((req, res, next) => {
+      console.log('!!!!!', req._parsedUrl.pathname)
       res.on('finish', () => {
         MetricsHandler.endpointHits.inc({
           method: req.method,
           // for example "/api/Auth/verify"
-          route: req.originalUrl,
+          route: req._parsedUrl.pathname,
           statusCode: res.statusCode,
         });
       });

--- a/api/util/SceHttpServer.js
+++ b/api/util/SceHttpServer.js
@@ -57,7 +57,6 @@ class SceHttpServer {
 
   registerMetricsMiddleware() {
     this.app.use((req, res, next) => {
-      console.log('!!!!!', req._parsedUrl.pathname)
       res.on('finish', () => {
         MetricsHandler.endpointHits.inc({
           method: req.method,

--- a/nginx.conf
+++ b/nginx.conf
@@ -42,11 +42,13 @@ http {
 
         location ~ /s/(.*)$ {
             proxy_set_header X-Original-URL "$scheme://$host$request_uri";
+            proxy_set_header X-Base-URL "$scheme://$host";
             proxy_pass http://cleezy-nginx.sce;
         }
 
         location ~ /qr/(.*)$ {
             proxy_set_header X-Original-URL "$scheme://$host$request_uri";
+            proxy_set_header X-Base-URL "$scheme://$host";
             proxy_pass http://cleezy-nginx.sce;
         }
         

--- a/nginx.conf
+++ b/nginx.conf
@@ -41,11 +41,13 @@ http {
         ssl_protocols TLSv1.2 TLSv1.3;
 
         location ~ /s/(.*)$ {
-          proxy_pass http://cleezy-nginx.sce;
+            proxy_set_header X-Original-URI $request_uri;
+            proxy_pass http://cleezy-nginx.sce;
         }
 
         location ~ /qr/(.*)$ {
-          proxy_pass http://cleezy-nginx.sce;
+            proxy_set_header X-Original-URI $request_uri;
+            proxy_pass http://cleezy-nginx.sce;
         }
         
         location ~ ^/transit/ {

--- a/nginx.conf
+++ b/nginx.conf
@@ -41,12 +41,12 @@ http {
         ssl_protocols TLSv1.2 TLSv1.3;
 
         location ~ /s/(.*)$ {
-            proxy_set_header X-Original-URI $request_uri;
+            proxy_set_header X-Original-URL "$scheme://$host$request_uri";
             proxy_pass http://cleezy-nginx.sce;
         }
 
         location ~ /qr/(.*)$ {
-            proxy_set_header X-Original-URI $request_uri;
+            proxy_set_header X-Original-URL "$scheme://$host$request_uri";
             proxy_pass http://cleezy-nginx.sce;
         }
         


### PR DESCRIPTION
#1611 worked, but it was including query parameters in the route labels like `/api/something?key=value`

this removes the query parameters from the label so we get consistent labels across api requests, i.e. `/api/something`