### PR TITLE
use url.parse in prometheus route label for api requests

### DIFF
--- a/api/util/SceHttpServer.js
+++ b/api/util/SceHttpServer.js
@@ -4,6 +4,7 @@ const cors = require('cors');
 const http = require('http');
 const mongoose = require('mongoose');
 mongoose.Promise = require('bluebird');
+const url = require('url');
 
 const { PathParser } = require('./PathParser');
 const logger = require('./logger');
@@ -58,10 +59,12 @@ class SceHttpServer {
   registerMetricsMiddleware() {
     this.app.use((req, res, next) => {
       res.on('finish', () => {
+        // req.originalUrl can look like /api/path?key=value
+        const parsedUrl = url.parse(req.originalUrl, true);
         MetricsHandler.endpointHits.inc({
           method: req.method,
-          // for example "/api/Auth/verify"
-          route: req.baseUrl,
+          // using the above example, pathname looks like '/api/path'
+          route: parsedUrl.pathname,
           statusCode: res.statusCode,
         });
       });

--- a/api/util/SceHttpServer.js
+++ b/api/util/SceHttpServer.js
@@ -61,7 +61,7 @@ class SceHttpServer {
         MetricsHandler.endpointHits.inc({
           method: req.method,
           // for example "/api/Auth/verify"
-          route: req._parsedUrl.pathname,
+          route: req.baseUrl,
           statusCode: res.statusCode,
         });
       });


### PR DESCRIPTION
this is the actual fix, node behavior in docker is different than my local node version

![image](https://github.com/user-attachments/assets/8e417015-afa5-4a8e-aca3-2ca8c0353f55)

```
sce-main-endpoints-dev  |     baseUrl: '/api/Advertisement',
sce-main-endpoints-dev  |     originalUrl: '/api/Advertisement?asdf=123',
```