### PR TITLE
Add hyperlinks to club announcement messages (#1569)

### DIFF
--- a/src/Pages/Home/Home.js
+++ b/src/Pages/Home/Home.js
@@ -24,9 +24,21 @@ const Home = () => {
     getMessage();
   }, []);
 
+  function isValidUrl(str) {
+  try {
+    new URL(str);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
   function renderMessageWithLinks(message) {
+    if (!message) {
+      return null;
+    }
     return message.split(/(https?:\/\/[^\s]+)/g).map((part, index) => {
-      if (/https?:\/\/[^\s]+/.test(part)) {
+      if (isValidUrl(part)) {
         return (
           <a
             key={index}

--- a/src/Pages/Home/Home.js
+++ b/src/Pages/Home/Home.js
@@ -9,7 +9,6 @@ const Home = () => {
 
   const [message, setMessage] = useState('');
   const [showMessage, setShowMessage] = useState(false);
-
   async function getMessage() {
     try {
       const messageData = await getAd();
@@ -26,21 +25,23 @@ const Home = () => {
   }, []);
 
   function renderMessageWithLinks(message) {
-    return message.split(/(https?:\/\/[^\s]+)/g).map((part, index) =>
-      /https?:\/\/[^\s]+/.test(part) ? (
-        <a
-          key={index}
-          href={part}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-blue-400 underline"
-        >
-          {part}
-        </a>
-      ) : (
-        <span key={index}>{part}</span>
-      )
-    );
+    return message.split(/(https?:\/\/[^\s]+)/g).map((part, index) => {
+      if (/https?:\/\/[^\s]+/.test(part)) {
+        return (
+          <a
+            key={index}
+            href={part}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-400 underline"
+          >
+            {part}
+          </a>
+        );
+      }
+
+      return <span key={index}>{part}</span>;
+    });
   }
 
   return (

--- a/src/Pages/Home/Home.js
+++ b/src/Pages/Home/Home.js
@@ -25,6 +25,24 @@ const Home = () => {
     getMessage();
   }, []);
 
+  function renderMessageWithLinks(message) {
+    return message.split(/(https?:\/\/[^\s]+)/g).map((part, index) =>
+      /https?:\/\/[^\s]+/.test(part) ? (
+        <a
+          key={index}
+          href={part}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-400 underline"
+        >
+          {part}
+        </a>
+      ) : (
+        <span key={index}>{part}</span>
+      )
+    );
+  }
+
   return (
     <div className='flex flex-col min-h-[calc(100vh-86px)] z-[-200] bg-gradient-to-r from-gray-800 to-gray-600'>
       <div className = "flex flex-col items-center justify-center my-4">
@@ -35,21 +53,7 @@ const Home = () => {
           className="text-white"
           style={{ display: showMessage ? 'block' : 'none' }} // Conditional display based on state
         >
-          {message.split(/(https?:\/\/[^\s]+)/g).map((part, index) =>
-            /https?:\/\/[^\s]+/.test(part) ? (
-              <a
-                key={index}
-                href={part}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-400 underline"
-              >
-                {part}
-              </a>
-            ) : (
-              <span key={index}>{part}</span>
-            )
-          )}
+          {renderMessageWithLinks(message)}
         </motion.p>
       </div>
       <div className="flex flex-col flex-wrap items-center justify-center flex-1 h-full my-4 md:flex-row xl:my-0">

--- a/src/Pages/Home/Home.js
+++ b/src/Pages/Home/Home.js
@@ -25,13 +25,13 @@ const Home = () => {
   }, []);
 
   function isValidUrl(str) {
-  try {
-    new URL(str);
-    return true;
-  } catch (_) {
-    return false;
+    try {
+      new URL(str);
+      return true;
+    } catch (_) {
+      return false;
+    }
   }
-}
 
   function renderMessageWithLinks(message) {
     if (!message) {

--- a/src/Pages/Home/Home.js
+++ b/src/Pages/Home/Home.js
@@ -35,7 +35,21 @@ const Home = () => {
           className="text-white"
           style={{ display: showMessage ? 'block' : 'none' }} // Conditional display based on state
         >
-          {message}
+          {message.split(/(https?:\/\/[^\s]+)/g).map((part, index) =>
+            /https?:\/\/[^\s]+/.test(part) ? (
+              <a
+                key={index}
+                href={part}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-400 underline"
+              >
+                {part}
+              </a>
+            ) : (
+              <span key={index}>{part}</span>
+            )
+          )}
         </motion.p>
       </div>
       <div className="flex flex-col flex-wrap items-center justify-center flex-1 h-full my-4 md:flex-row xl:my-0">


### PR DESCRIPTION
# Changes
Formats URLs in club announcements as clickable links
Links are underlined, blue, and open in a new tab


# Screenshots


**Before:**
![before](https://github.com/user-attachments/assets/51352179-397b-4424-b8cc-1108ea810310)

**After:**
![after](https://github.com/user-attachments/assets/0e0121e7-2521-4b0d-89a0-731e992a9a57)
Closes #1569
