### PR TITLE
Add test verifying login succeeds with correct credentials

### DIFF
--- a/test/api/Auth.js
+++ b/test/api/Auth.js
@@ -210,14 +210,14 @@ describe('Auth', () => {
 
       const decodedPayload = decodeToken(mockRequest);
       const expectedPayload = {
-        firstName: user.firstName,
-        lastName: user.lastName,
-        email: user.email,
-        accessLevel: decodedPayload.accessLevel,
-        pagesPrinted: decodedPayload.pagesPrinted,
+        firstName: 'Test',
+        lastName: 'User',
+        email: 'logintest@gmail.com',
+        accessLevel: MEMBERSHIP_STATE.PENDING,
+        pagesPrinted: 0,
         _id: decodedPayload._id,
         iat: decodedPayload.iat,
-        exp: decodedPayload.exp
+        exp: decodedPayload.exp,
       }
 
       expect(decodedPayload).to.deep.equal(expectedPayload)

--- a/test/api/Auth.js
+++ b/test/api/Auth.js
@@ -17,6 +17,8 @@ const {
 } = require('../../api/util/constants').STATUS_CODES;
 const SceApiTester = require('../util/tools/SceApiTester');
 
+const {decodeToken} = require('../../api/main_endpoints/util/token-functions.js')
+
 let app = null;
 let test = null;
 let sandbox = sinon.createSandbox();
@@ -171,6 +173,56 @@ describe('Auth', () => {
         '/api/Auth/login', user);
       expect(result).to.have.status(UNAUTHORIZED);
     });
+
+    it('Should allow login with correct credentials after registering a user', async () => {
+      const user = {
+        email: 'logintest@gmail.com',
+        password: 'ValidTestPass123!',
+        firstName: 'Test',
+        lastName: 'User'
+      }
+
+      // register the user first
+      const registerUser = await test.sendPostRequest('/api/Auth/register', user);
+      expect(registerUser).to.have.status(OK);
+
+      // verify the email
+      await User.updateOne({email: user.email}, {$set: {emailVerified: true}})
+
+      // then try logging in with the same credentials
+      const loginUser = await test.sendPostRequest('/api/Auth/login', {
+        email: user.email,
+        password: user.password
+      });
+
+      expect(loginUser).to.have.status(OK);
+      expect(loginUser.body).to.have.property('token');
+
+      const token = loginUser.body.token;
+      expect(token).to.be.a('string');
+      expect(token.startsWith('JWT ')).to.be.true;
+
+      const mockRequest = {
+        headers: {
+          authorization: `Bearer ${token}`
+        }
+      };
+
+      const decodedPayload = decodeToken(mockRequest);
+      const expectedPayload = {
+        firstName: user.firstName,
+        lastName: user.lastName,
+        email: user.email,
+        accessLevel: decodedPayload.accessLevel,
+        pagesPrinted: decodedPayload.pagesPrinted,
+        _id: decodedPayload._id,
+        iat: decodedPayload.iat,
+        exp: decodedPayload.exp
+      }
+
+      expect(decodedPayload).to.deep.equal(expectedPayload)
+
+    })
   });
 
   describe('/POST sendPasswordReset', () => {

--- a/test/api/Auth.js
+++ b/test/api/Auth.js
@@ -17,7 +17,7 @@ const {
 } = require('../../api/util/constants').STATUS_CODES;
 const SceApiTester = require('../util/tools/SceApiTester');
 
-const {decodeToken} = require('../../api/main_endpoints/util/token-functions.js')
+const {decodeToken} = require('../../api/main_endpoints/util/token-functions.js');
 
 let app = null;
 let test = null;
@@ -180,49 +180,52 @@ describe('Auth', () => {
         password: 'ValidTestPass123!',
         firstName: 'Test',
         lastName: 'User'
-      }
-
-      // register the user first
-      const registerUser = await test.sendPostRequest('/api/Auth/register', user);
-      expect(registerUser).to.have.status(OK);
-
-      // verify the email
-      await User.updateOne({email: user.email}, {$set: {emailVerified: true}})
-
-      // then try logging in with the same credentials
-      const loginUser = await test.sendPostRequest('/api/Auth/login', {
-        email: user.email,
-        password: user.password
-      });
-
-      expect(loginUser).to.have.status(OK);
-      expect(loginUser.body).to.have.property('token');
-
-      const token = loginUser.body.token;
-      expect(token).to.be.a('string');
-      expect(token.startsWith('JWT ')).to.be.true;
-
-      const mockRequest = {
-        headers: {
-          authorization: `Bearer ${token}`
-        }
       };
 
-      const decodedPayload = decodeToken(mockRequest);
-      const expectedPayload = {
-        firstName: 'Test',
-        lastName: 'User',
-        email: 'logintest@gmail.com',
-        accessLevel: MEMBERSHIP_STATE.PENDING,
-        pagesPrinted: 0,
-        _id: decodedPayload._id,
-        iat: decodedPayload.iat,
-        exp: decodedPayload.exp,
+      try {
+      // register the user first
+        const registerUser = await test.sendPostRequest('/api/Auth/register', user);
+        expect(registerUser).to.have.status(OK);
+
+        // verify the email
+        await User.updateOne({email: user.email}, {$set: {emailVerified: true}});
+
+        // then try logging in with the same credentials
+        const loginUser = await test.sendPostRequest('/api/Auth/login', {
+          email: user.email,
+          password: user.password
+        });
+
+        expect(loginUser).to.have.status(OK);
+        expect(loginUser.body).to.have.property('token');
+
+        const token = loginUser.body.token;
+        expect(token).to.be.a('string');
+        expect(token.startsWith('JWT ')).to.be.true;
+
+        const mockRequest = {
+          headers: {
+            authorization: `Bearer ${token}`
+          }
+        };
+
+        const decodedPayload = decodeToken(mockRequest);
+        const expectedPayload = {
+          firstName: 'Test',
+          lastName: 'User',
+          email: 'logintest@gmail.com',
+          accessLevel: MEMBERSHIP_STATE.PENDING,
+          pagesPrinted: 0,
+          _id: decodedPayload._id,
+          iat: decodedPayload.iat,
+          exp: decodedPayload.exp,
+        };
+
+        expect(decodedPayload).to.deep.equal(expectedPayload);
+      } finally {
+        await User.deleteOne({email: user.email});
       }
-
-      expect(decodedPayload).to.deep.equal(expectedPayload)
-
-    })
+    });
   });
 
   describe('/POST sendPasswordReset', () => {


### PR DESCRIPTION
This PR adds a test that first registers a user, sets their email as verified, and then attempts to log in using the same credentials. It verifies that the login succeeds and that the returned token contains the correct structure and user information.

Addresses issue #1682.