### PR TITLE
Upgraded Shortcut Search: added cleezy search to route/ShortcutSearch.js

### DIFF
--- a/api/main_endpoints/routes/Cleezy.js
+++ b/api/main_endpoints/routes/Cleezy.js
@@ -4,6 +4,7 @@ const router = express.Router();
 const {
   decodeToken,
   checkIfTokenSent,
+  checkIfTokenValid,
 } = require('../util/token-functions.js');
 const {
   OK,
@@ -13,6 +14,7 @@ const {
 } = require('../../util/constants').STATUS_CODES;
 const logger = require('../../util/logger');
 const { Cleezy } = require('../../config/config.json');
+const membershipState = require('../../util/constants').MEMBERSHIP_STATE;
 const { ENABLED } = Cleezy;
 
 let CLEEZY_URL = process.env.CLEEZY_URL
@@ -97,14 +99,19 @@ router.post('/deleteUrl', async (req, res) => {
     });
 });
 
+const searchCleezyUrls = async (req) => {
+  if(!ENABLED || !req.body.query) {
+    return { status: OK, data: [] };
+  }
 
-const searchCleezyUrls = async (query) => {
-  if(!ENABLED || !query) {
-    return;
+  if (!checkIfTokenSent(req)) {
+    return { status: FORBIDDEN, data: [] };
+  } else if (!checkIfTokenValid(req, membershipState.OFFICER)) {
+    return { status: UNAUTHORIZED, data: [] };
   }
 
   try {
-    const cleezyQuery = query.replace(/[^a-zA-Z0-9]/g, '');
+    const cleezyQuery = req.body.query.replace(/[^a-zA-Z0-9]/g, '');
     const cleezyRes = await axios.get(CLEEZY_URL + '/list', {
       params: {
         search: cleezyQuery
@@ -117,9 +124,10 @@ const searchCleezyUrls = async (query) => {
         return { ...e, link: u.href };
       });
 
-    return cleezyData;
+    return { status: OK, data: cleezyData };
   } catch (err) {
     logger.error('cleezy search urls had an error', err);
+    return { status: SERVER_ERROR, data: [] };
   }
 };
 

--- a/api/main_endpoints/routes/Cleezy.js
+++ b/api/main_endpoints/routes/Cleezy.js
@@ -97,4 +97,30 @@ router.post('/deleteUrl', async (req, res) => {
     });
 });
 
-module.exports = router;
+
+const searchCleezyUrls = async (query) => {
+  if(!ENABLED || !query) {
+    return;
+  }
+
+  try {
+    const cleezyQuery = query.replace(/[^a-zA-Z0-9]/g, '');
+    const cleezyRes = await axios.get(CLEEZY_URL + '/list', {
+      params: {
+        search: cleezyQuery
+      }
+    });
+    const cleezyData = cleezyRes.data?.data
+      .slice(0, 5)
+      .map(e => {
+        const u = new URL(e.alias, URL_SHORTENER_BASE_URL);
+        return { ...e, link: u.href };
+      });
+
+    return cleezyData;
+  } catch (err) {
+    logger.error('cleezy search urls had an error', err);
+  }
+};
+
+module.exports = {router, searchCleezyUrls};

--- a/api/main_endpoints/routes/ShortcutSearch.js
+++ b/api/main_endpoints/routes/ShortcutSearch.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const express = require('express');
-const axios = require('axios');
 const router = express.Router();
 const User = require('../models/User.js');
 const {
@@ -18,11 +17,7 @@ const membershipState = require('../../util/constants').MEMBERSHIP_STATE;
 const logger = require('../../util/logger');
 const { Cleezy } = require('../../config/config.json');
 const { ENABLED } = Cleezy;
-
-let CLEEZY_URL = process.env.CLEEZY_URL
-  || 'http://localhost:8000';
-let URL_SHORTENER_BASE_URL =
-  process.env.NODE_ENV === 'production' ? 'https://sce.sjsu.edu/s/' : 'http://localhost:8000/find/';
+const cleezy = require('../routes/Cleezy.js');
 
 // Search for all members using either first name, last name or email
 // Search for all cleezy urls using either alias or url
@@ -43,7 +38,6 @@ router.post('/', async function(req, res) {
   }
 
   const query = req.body.query.replace(/[*\s]/g, '');
-  const cleezyQuery = req.body.query.replace(/[^a-zA-Z0-9]/g, '');
 
   // Create a fuzzy regex pattern to match characters in order, e.g., "pone" -> /p.*o.*n.*e/i
   const fuzzyPattern = query.split('').join('.*');
@@ -115,7 +109,7 @@ router.post('/', async function(req, res) {
     const users = await User.find(maybeOr, { password: 0 }).limit(5);
     users.sort(sortByMatch(req.body.query));
 
-    // Short circuit if cleezy is disable
+    // Short circuit if cleezy is disabled
     if(!ENABLED) {
       return res.status(OK).json({
         items: {users, cleezyData: []},
@@ -123,18 +117,7 @@ router.post('/', async function(req, res) {
       });
     }
 
-    const cleezyRes = await axios.get(CLEEZY_URL + '/list', {
-      params: {
-        search: cleezyQuery
-      }
-    });
-
-    const cleezyData = cleezyRes.data?.data
-      .slice(0, 5)
-      .map(e => {
-        const u = new URL(e.alias, URL_SHORTENER_BASE_URL);
-        return { ...e, link: u.href };
-      });
+    const cleezyData = await cleezy.searchCleezyUrls(req.body.query);
 
     res.status(OK).send({ items: {users, cleezyData} });
   } catch (error) {

--- a/api/main_endpoints/routes/ShortcutSearch.js
+++ b/api/main_endpoints/routes/ShortcutSearch.js
@@ -117,9 +117,24 @@ router.post('/', async function(req, res) {
       });
     }
 
-    const cleezyData = await cleezy.searchCleezyUrls(req.body.query);
+    const cleezyRes = await cleezy.searchCleezyUrls(req);
+    if (cleezyRes.status !== OK) {
+      logger.warn('Cleezy search failed', {
+        status: cleezyRes.status
+      });
 
-    res.status(OK).send({ items: {users, cleezyData} });
+      return res.status(OK).send({
+        cleezyStatus: cleezyRes.status,
+        items: { users }
+      });
+    }
+
+    return res.status(OK).send({
+      items: {
+        users,
+        cleezyData: cleezyRes.data,
+      }
+    });
   } catch (error) {
     logger.error('/shortcutsearch encountered an error:', { error, query: req.body.query });
     if (error.response && error.response.data) {

--- a/api/main_endpoints/routes/ShortcutSearch.js
+++ b/api/main_endpoints/routes/ShortcutSearch.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const express = require('express');
+const axios = require('axios');
 const router = express.Router();
 const User = require('../models/User.js');
 const {
@@ -11,11 +12,20 @@ const {
   OK,
   UNAUTHORIZED,
   FORBIDDEN,
+  SERVER_ERROR,
 } = require('../../util/constants').STATUS_CODES;
 const membershipState = require('../../util/constants').MEMBERSHIP_STATE;
 const logger = require('../../util/logger');
+const { Cleezy } = require('../../config/config.json');
+const { ENABLED } = Cleezy;
+
+let CLEEZY_URL = process.env.CLEEZY_URL
+  || 'http://localhost:8000';
+let URL_SHORTENER_BASE_URL =
+  process.env.NODE_ENV === 'production' ? 'https://sce.sjsu.edu/s/' : 'http://localhost:8000/find/';
 
 // Search for all members using either first name, last name or email
+// Search for all cleezy urls using either alias or url
 router.post('/', async function(req, res) {
   if (!checkIfTokenSent(req)) {
     return res.sendStatus(FORBIDDEN);
@@ -24,10 +34,16 @@ router.post('/', async function(req, res) {
   }
 
   if (!req.body.query) {
-    return res.status(OK).send({ items: [] });
+    return res.status(OK).send({
+      items: {
+        users: [],
+        cleezyData: [],
+      }
+    });
   }
 
   const query = req.body.query.replace(/[*\s]/g, '');
+  const cleezyQuery = req.body.query.replace(/[^a-zA-Z0-9]/g, '');
 
   // Create a fuzzy regex pattern to match characters in order, e.g., "pone" -> /p.*o.*n.*e/i
   const fuzzyPattern = query.split('').join('.*');
@@ -95,16 +111,40 @@ router.post('/', async function(req, res) {
   };
 
   // Find user and sort results based on best match of full name or email
-  User.find(maybeOr, { password: 0 })
-    .limit(5)
-    .then(items => {
-      items.sort(sortByMatch(req.body.query));
-      res.status(OK).send({ items });
-    })
-    .catch((error) => {
-      logger.error('/shortcutsearchusers encountered an error:', error);
-      res.sendStatus(BAD_REQUEST);
+  try{
+    const users = await User.find(maybeOr, { password: 0 }).limit(5);
+    users.sort(sortByMatch(req.body.query));
+
+    // Short circuit if cleezy is disable
+    if(!ENABLED) {
+      return res.status(OK).json({
+        items: {users, cleezyData: []},
+        disabled: true
+      });
+    }
+
+    const cleezyRes = await axios.get(CLEEZY_URL + '/list', {
+      params: {
+        search: cleezyQuery
+      }
     });
+
+    const cleezyData = cleezyRes.data?.data
+      .slice(0, 5)
+      .map(e => {
+        const u = new URL(e.alias, URL_SHORTENER_BASE_URL);
+        return { ...e, link: u.href };
+      });
+
+    res.status(OK).send({ items: {users, cleezyData} });
+  } catch (error) {
+    logger.error('/shortcutsearch encountered an error:', { error, query: req.body.query });
+    if (error.response && error.response.data) {
+      res.status(error.response.status).json({ error: error.response.data });
+    } else {
+      res.status(SERVER_ERROR).json({ error: 'Failed to search for Users or URLs' });
+    }
+  }
 });
 
 module.exports = router;

--- a/src/APIFunctions/ShortcutSearch.js
+++ b/src/APIFunctions/ShortcutSearch.js
@@ -2,13 +2,13 @@ import { UserApiResponse } from './ApiResponses';
 import { BASE_API_URL } from '../Enums';
 
 /**
- * Queries the database for all users.
+ * Queries the database for all users and cleezy URLs.
  * @param {string} token The jwt token for verification
  * @param {string} query The search query to filter users by name or email.
  * @returns {UserApiResponse} Containing any error information or the array of
  * users.
  */
-export async function searchAllUsers({
+export async function searchUsersAndCleezyUrls({
   token,
   query = null
 }) {

--- a/src/Components/ShortcutKeyModal/SearchModal.js
+++ b/src/Components/ShortcutKeyModal/SearchModal.js
@@ -4,7 +4,7 @@ import { officerOrAdminRoutes, signedOutRoutes, memberRoutes, notAuthenticatedRo
 import { membershipState } from '../../Enums';
 import { useUser } from '../context/UserContext';
 import { useAuth } from '../context/AuthContext';
-import { searchAllUsers } from '../../APIFunctions/ShortcutSearch';
+import { searchUsersAndCleezyUrls } from '../../APIFunctions/ShortcutSearch';
 
 export default function SearchModal() {
   const [open, setOpen] = useState(false);
@@ -19,6 +19,8 @@ export default function SearchModal() {
   const { authenticated } = useAuth();
   // Maximum number of suggestions to display in the search dropdown
   const SHORTCUT_MAX_RESULT = 5;
+  const DEBOUNCE_TIME = 400;
+  const [isCleezyDisabled, setIsCleezyDisabled] = useState(false);
 
   /**
    * Returns the appropriate routes array based on the user's access level.
@@ -58,18 +60,33 @@ export default function SearchModal() {
     setKeyword('');
   };
 
+  /**
+   * Displays a confirmation prompt if the selected item is an external link.
+   * @param {*} r - A route object from the suggestions list.
+   * @returns Returns false if the route is an external site and navigate user to URL shortened page.
+   */
+  const externalSiteRoute = (r) => {
+    if (r.type === 'external_url') {
+      const encodedRoute = encodeURIComponent(JSON.stringify(r));
+      window.location.href = `/short?data=${encodedRoute}`;
+      return true;
+    }
+    return false;
+  };
+
   const SuggestionsList = () => {
     if (suggestions.length === 0) return <></>;
 
     const topFiveItems = suggestions.slice(0, SHORTCUT_MAX_RESULT);
     return (
       <ul className='suggestion-list'>
-        {topFiveItems.map((r, index) => ( // Still keep index to keep track of the selected item
+        {topFiveItems.map((r, index) => (
           <li
             key={r.path} // Use r.path as key
             className={`suggestion-item ${index === selectItem ? 'active' : ''}`}
             onMouseMove={() => setSelectItem(index)}
             onClick={() => {
+              if (externalSiteRoute(r)) return;
               window.location.href = r.path;
               setOpen(false);
             }}
@@ -80,7 +97,7 @@ export default function SearchModal() {
             <div className='text-wrapper'>
               {r.pageName}
               <div className='hidden-tab'>
-                {selectItem === index && `${window.location.origin}${r.path}`}
+                {selectItem === index && (r.type === 'external_url' ? r.path : `${window.location.origin}${r.path}`)}
               </div>
             </div>
           </li>
@@ -90,26 +107,43 @@ export default function SearchModal() {
   };
 
   /**
-   * Async function fetches all user data from the API
+   * Async function that calls an API to fetch matching users and URL data
    * @param {string} token - User's authentication token.
    * @param {string} query - The search term.
    */
-  const getUserData = async ({ token, query }) => {
+  const getUserAndCleezyData = async ({ token, query }) => {
     try {
-      const apiResponse = await searchAllUsers({
+      const apiResponse = await searchUsersAndCleezyUrls({
         token,
         query
       });
+      const {disabled, items} = apiResponse.responseData || {};
+      let userMatches = [];
+      let urlMatches = [];
+      setIsCleezyDisabled(!!disabled);
 
-      if (apiResponse.error || apiResponse.responseData.items.length === 0) return; // Exit early if there's an API error or an empty array
+      if (apiResponse.error || !items) return; // Exit early if there's an API error
 
-      const userMatches = apiResponse.responseData.items
-        .map((u) => ({
-          pageName: `${u.firstName} ${u.lastName} (${u.email})`,
-          path: `/user/edit/${u._id}`,
-          type: 'user'
-        }));
-      setSuggestions(prev => [...prev, ...userMatches]);
+      if (items.users?.length > 0) {
+        userMatches = items.users
+          .map((u) => ({
+            pageName: `${u.firstName} ${u.lastName} (${u.email})`,
+            path: `/user/edit/${u._id}`,
+            type: 'user'
+          }));
+      }
+
+      if (!isCleezyDisabled && items.cleezyData?.length > 0) {
+        urlMatches = items.cleezyData
+          .map((u) => ({
+            ...u,
+            pageName: u.alias,
+            path: u.url,
+            type: 'external_url'
+          }));
+      }
+
+      setSuggestions(prev => [...prev, ...userMatches, ...urlMatches]);
     } catch (error) {
       setErrorMsg(error.message);
     }
@@ -137,23 +171,30 @@ export default function SearchModal() {
 
   /**
    * A debounce function that performs the search 400ms after the user stops typing.
-   * @dependencies keyword, open, user.accessLevel
+   * @dependencies keyword, open, user.accessLevel, user.token
    */
   useEffect(() => {
-    if (!open ||
+    if (
+      !open ||
       !user.accessLevel ||
       user?.accessLevel < membershipState.OFFICER ||
-      !keyword) return;
+      !keyword
+    ) return;
 
     const debounce = setTimeout(() => {
-      getUserData({
+      getUserAndCleezyData({
         token: user.token,
         query: keyword
       });
-    }, 400);
+    }, DEBOUNCE_TIME);
 
     return () => clearTimeout(debounce);
-  }, [keyword, open, user.accessLevel]);
+  }, [
+    keyword,
+    open,
+    user.accessLevel,
+    user.token
+  ]);
 
   /**
    * Executes a search when Enter is pressed
@@ -164,6 +205,7 @@ export default function SearchModal() {
 
     const target = suggestions[selectItem];
     if (target && target.path) {
+      if (externalSiteRoute(target)) return;
       window.location.href = target.path;
       setOpen(false);
       clearSearchModal();

--- a/src/Pages/URLShortener/URLShortener.js
+++ b/src/Pages/URLShortener/URLShortener.js
@@ -30,6 +30,8 @@ export default function URLShortenerPage() {
   const [toggleDelete, setToggleDelete] = useState(false);
   const [currentSortColumn, setCurrentSortColumn] = useState(null);
   const [currentSortOrder, setCurrentSortOrder] = useState(null);
+  const query = new URLSearchParams(window.location.search);
+  const rawData = query.get('data');
 
   const INPUT_CLASS = 'indent-2 block w-full rounded-md border-0 py-1.5 text-slate-800 dark:text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-slate-700 dark:placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6 text-gray';
   const LABEL_CLASS = 'block text-sm font-medium leading-6 text-slate-800 dark:text-gray-300';
@@ -179,7 +181,19 @@ export default function URLShortenerPage() {
   }, [alias]);
 
   useEffect(() => {
-    getCleezyUrls(page, searchQuery, currentSortColumn, currentSortOrder);
+    if (rawData) {
+      const parsedObject = JSON.parse(decodeURIComponent(rawData));
+
+      if (!parsedObject) return;
+      setAllUrls([parsedObject]);
+
+      // remove ?data=... from URL
+      const url = new URL(window.location);
+      url.searchParams.delete('data');
+      window.history.replaceState({}, '', url);
+    } else {
+      getCleezyUrls(page, searchQuery, currentSortColumn, currentSortOrder);
+    }
   }, [page, currentSortColumn, currentSortOrder]);
 
   function maybeRenderErrorAlert() {

--- a/test/api/ShortcutSearch.js
+++ b/test/api/ShortcutSearch.js
@@ -1,6 +1,9 @@
 process.env.NODE_ENV = 'test';
 
 const User = require('../../api/main_endpoints/models/User.js');
+const axios = require('axios');
+const { Cleezy } = require('../../api/config/config.json');
+const { ENABLED } = Cleezy;
 
 // Require the dev-dependencies
 const chai = require('chai');
@@ -12,6 +15,7 @@ const {
   FORBIDDEN
 } = require('../../api/util/constants').STATUS_CODES;
 const SceApiTester = require('../util/tools/SceApiTester');
+const sinon = require('sinon');
 
 let app = null;
 let test = null;
@@ -196,19 +200,20 @@ describe('ShortcutSearch', () => {
       it('Should return an empty array when the query is missing', async () => {
         const result = await test.sendPostRequestWithToken(token, url, {});
         expect(result).to.have.status(OK);
-        expect(result.body.items).that.is.an('array').that.is.empty;
+        expect(result.body.items.users).that.is.an('array').that.is.empty;
+        expect(result.body.items.cleezyData).that.is.an('array').that.is.empty;
       });
 
       it('Should return FIVE records when query = \'Lot\'', async () => {
         const result = await test.sendPostRequestWithToken(token, url, fiveMatchUsers);
         expect(result).to.have.status(OK);
-        expect(result.body.items).that.is.an('array').to.have.lengthOf(5);
+        expect(result.body.items.users).that.is.an('array').to.have.lengthOf(5);
       });
 
       it('Should return no records when query = \'Pika\'', async () => {
         const result = await test.sendPostRequestWithToken(token, url, { query: 'Pika' });
         expect(result).to.have.status(OK);
-        expect(result.body.items).that.is.an('array').that.is.empty;
+        expect(result.body.items.users).that.is.an('array').that.is.empty;
       });
 
       beforeEach(() => {
@@ -218,13 +223,13 @@ describe('ShortcutSearch', () => {
       it('Should return THREE records when query = \'coOl\'', async () => {
         const result = await test.sendPostRequestWithToken(token, url, queryUser);
         expect(result).to.have.status(OK);
-        expect(result.body.items).that.is.an('array').to.have.lengthOf(3);
+        expect(result.body.items.users).that.is.an('array').to.have.lengthOf(3);
       });
 
       it('Should show results sorted by best match of name and email', async () => {
         const result = await test.sendPostRequestWithToken(token, url, fiveMatchUsers);
         expect(result).to.have.status(OK);
-        expect(result.body.items.map(u => u.email)).to.eql([
+        expect(result.body.items.users.map(u => u.email)).to.eql([
           'test1@test.com',
           'test0@test.com',
           'test00@test.com',
@@ -256,8 +261,62 @@ describe('ShortcutSearch', () => {
         for (const payload of injectionPayloads) {
           const result = await test.sendPostRequestWithToken(token, url, { query: String(payload)});
           expect(result).to.have.status(OK);
-          expect(result.body.items.length).at.most(5);
+          expect(result.body.items.users.length).at.most(5);
+          expect(result.body.items.cleezyData.length).at.most(5);
         }
+      });
+    });
+
+    let axiosGetStub;
+
+    beforeEach(() => {
+      axiosGetStub = sinon.stub(axios, 'get').resolves({
+        data: {
+          data: [
+            {
+              alias: 'only-link',
+              url: 'https://example.com/something',
+            },
+            {
+              alias: 'cool-link',
+              url: 'https://example.com/another',
+            },
+            {
+              alias: 'test-link',
+              url: 'https://example.com/test',
+            },
+            {
+              alias: 'new-link',
+              url: 'https://example.com/justlink',
+            },
+            {
+              alias: 'test-link',
+              url: 'https://example.com/test',
+            },
+            {
+              alias: 'sixth-link',
+              url: 'https://example.com/six',
+            }
+          ]
+        }
+      });
+    });
+
+    afterEach(() => {
+      axiosGetStub.restore();
+    });
+
+    describe('When Cleezy is ENABLED with a valid token and access level - status code 200', () => {
+      if (!ENABLED) return;
+
+      beforeEach(() => {
+        setTokenStatus(true, { accessLevel: MEMBERSHIP_STATE.OFFICER });
+      });
+
+      it('Should return FIVE records when query = \'link\'', async () => {
+        const result = await test.sendPostRequestWithToken(token, url, {query : 'link'});
+        expect(result).to.have.status(OK);
+        expect(result.body.items.cleezyData).that.is.an('array').to.have.lengthOf(5);
       });
     });
 

--- a/test/api/ShortcutSearch.js
+++ b/test/api/ShortcutSearch.js
@@ -53,7 +53,7 @@ describe('ShortcutSearch', () => {
     // Before each test we empty the database
     await tools.emptySchema(User);
     const testUser = new User({
-      email: 'a@b.c',
+      email: 'shortcutsearch@b.c',
       password: 'Passw0rd',
       firstName: 'firstName',
       lastName: 'lastName',

--- a/test/api/ShortcutSearch.js
+++ b/test/api/ShortcutSearch.js
@@ -1,9 +1,6 @@
 process.env.NODE_ENV = 'test';
 
 const User = require('../../api/main_endpoints/models/User.js');
-const axios = require('axios');
-const { Cleezy } = require('../../api/config/config.json');
-const { ENABLED } = Cleezy;
 
 // Require the dev-dependencies
 const chai = require('chai');
@@ -15,7 +12,6 @@ const {
   FORBIDDEN
 } = require('../../api/util/constants').STATUS_CODES;
 const SceApiTester = require('../util/tools/SceApiTester');
-const sinon = require('sinon');
 
 let app = null;
 let test = null;
@@ -264,59 +260,6 @@ describe('ShortcutSearch', () => {
           expect(result.body.items.users.length).at.most(5);
           expect(result.body.items.cleezyData.length).at.most(5);
         }
-      });
-    });
-
-    let axiosGetStub;
-
-    beforeEach(() => {
-      axiosGetStub = sinon.stub(axios, 'get').resolves({
-        data: {
-          data: [
-            {
-              alias: 'only-link',
-              url: 'https://example.com/something',
-            },
-            {
-              alias: 'cool-link',
-              url: 'https://example.com/another',
-            },
-            {
-              alias: 'test-link',
-              url: 'https://example.com/test',
-            },
-            {
-              alias: 'new-link',
-              url: 'https://example.com/justlink',
-            },
-            {
-              alias: 'test-link',
-              url: 'https://example.com/test',
-            },
-            {
-              alias: 'sixth-link',
-              url: 'https://example.com/six',
-            }
-          ]
-        }
-      });
-    });
-
-    afterEach(() => {
-      axiosGetStub.restore();
-    });
-
-    describe('When Cleezy is ENABLED with a valid token and access level - status code 200', () => {
-      if (!ENABLED) return;
-
-      beforeEach(() => {
-        setTokenStatus(true, { accessLevel: MEMBERSHIP_STATE.OFFICER });
-      });
-
-      it('Should return FIVE records when query = \'link\'', async () => {
-        const result = await test.sendPostRequestWithToken(token, url, {query : 'link'});
-        expect(result).to.have.status(OK);
-        expect(result.body.items.cleezyData).that.is.an('array').to.have.lengthOf(5);
       });
     });
 


### PR DESCRIPTION
Merge PR https://github.com/SCE-Development/Clark/pull/1829 first!
When Cleezy mode is enable, Officer and Admin can use shortcut search bar to search for created url alias.
1. Search for a shortened URL:
<img width="2559" height="1351" alt="image" src="https://github.com/user-attachments/assets/a24448bf-459b-4c73-9988-68d77747a471" />

2. Navigate users to URL shortened page with only that result visible:
<img width="2559" height="1350" alt="image" src="https://github.com/user-attachments/assets/875f9615-deaa-4ef8-8b89-5722effedefc" />

3. Users can continue using the URL shortened page as designed:
<img width="2559" height="1357" alt="image" src="https://github.com/user-attachments/assets/6db367d5-4ec4-42a1-a527-10678c747b50" />
 
