### PR TITLE
LED sign page, fixed text being white on light mode

### DIFF
--- a/src/Pages/LedSign/LedSign.js
+++ b/src/Pages/LedSign/LedSign.js
@@ -216,7 +216,7 @@ function LedSign() {
                       value={value}
                       id={id}
                       onChange={onChange}
-                      className="indent-2 text-white block w-full rounded-md border-0  shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
+                      className="indent-2 text-black dark:text-white block w-full rounded-md border-0 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-500 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
                       {...rest}
                     />
                   </div>


### PR DESCRIPTION
Previously, when using light mode for the LED sign page, the user inputted text would be white when using light mode, making it unreadable.

Now that issue has been fixed, and the text is now readable in both light mode and dark mode.