### PR TITLE
Debug: Filtered Vefify Email, Reset Password and Email Preferences pages

### DIFF
--- a/src/Components/ShortcutKeyModal/SearchModal.js
+++ b/src/Components/ShortcutKeyModal/SearchModal.js
@@ -12,8 +12,8 @@ export default function SearchModal() {
   const [open, setOpen] = useState(false);
   const inputRef = useRef(null);
   const modalRef = useRef(null);
-  const filter = ['Reset Password', 'Verify Email', 'Email Preferences'];
-  const filteredSignedOutRoutes = [...signedOutRoutes].filter(r => !filter.includes(r.pageName));
+  // const filter = ['Reset Password', 'Verify Email', 'Email Preferences'];
+  const filteredSignedOutRoutes = [...signedOutRoutes].filter(r => !r.hideFromShortcutSuggestions);
   const [keyword, setKeyword] = useState('');
   const [suggestions, setSuggestions] = useState([...filteredSignedOutRoutes]);
   const [selectItem, setSelectItem] = useState(0);
@@ -32,17 +32,17 @@ export default function SearchModal() {
   const routes = useMemo(() => {
     if (user?.accessLevel === membershipState.MEMBER)
       return [
-        ...memberRoutes.filter(r => r.pageName !== 'Edit User Info'),
+        ...memberRoutes.filter(r => !r.hideFromShortcutSuggestions),
         ...filteredSignedOutRoutes
       ];
     if (user?.accessLevel >= membershipState.OFFICER)
       return [
-        ...officerOrAdminRoutes.filter(r => r.pageName !== 'Edit User Info'),
+        ...officerOrAdminRoutes.filter(r => !r.hideFromShortcutSuggestions),
         ...filteredSignedOutRoutes
       ];
     if (!authenticated)
       return [
-        ...notAuthenticatedRoutes,
+        ...notAuthenticatedRoutes.filter(r => !r.hideFromShortcutSuggestions),
         ...filteredSignedOutRoutes
       ];
     return [...filteredSignedOutRoutes];

--- a/src/Components/ShortcutKeyModal/SearchModal.js
+++ b/src/Components/ShortcutKeyModal/SearchModal.js
@@ -12,7 +12,6 @@ export default function SearchModal() {
   const [open, setOpen] = useState(false);
   const inputRef = useRef(null);
   const modalRef = useRef(null);
-  // const filter = ['Reset Password', 'Verify Email', 'Email Preferences'];
   const filteredSignedOutRoutes = [...signedOutRoutes].filter(r => !r.hideFromShortcutSuggestions);
   const [keyword, setKeyword] = useState('');
   const [suggestions, setSuggestions] = useState([...filteredSignedOutRoutes]);

--- a/src/Components/ShortcutKeyModal/SearchModal.js
+++ b/src/Components/ShortcutKeyModal/SearchModal.js
@@ -12,8 +12,10 @@ export default function SearchModal() {
   const [open, setOpen] = useState(false);
   const inputRef = useRef(null);
   const modalRef = useRef(null);
+  const filter = ['Reset Password', 'Verify Email', 'Email Preferences'];
+  const filteredSignedOutRoutes = [...signedOutRoutes].filter(r => !filter.includes(r.pageName));
   const [keyword, setKeyword] = useState('');
-  const [suggestions, setSuggestions] = useState([...signedOutRoutes]);
+  const [suggestions, setSuggestions] = useState([...filteredSignedOutRoutes]);
   const [selectItem, setSelectItem] = useState(0);
   const { user } = useUser();
   const [errorMsg, setErrorMsg] = useState('');
@@ -31,19 +33,19 @@ export default function SearchModal() {
     if (user?.accessLevel === membershipState.MEMBER)
       return [
         ...memberRoutes.filter(r => r.pageName !== 'Edit User Info'),
-        ...signedOutRoutes
+        ...filteredSignedOutRoutes
       ];
     if (user?.accessLevel >= membershipState.OFFICER)
       return [
         ...officerOrAdminRoutes.filter(r => r.pageName !== 'Edit User Info'),
-        ...signedOutRoutes
+        ...filteredSignedOutRoutes
       ];
     if (!authenticated)
       return [
         ...notAuthenticatedRoutes,
-        ...signedOutRoutes
+        ...filteredSignedOutRoutes
       ];
-    return [...signedOutRoutes];
+    return [...filteredSignedOutRoutes];
   }, [user, authenticated]);
 
   /**
@@ -57,7 +59,7 @@ export default function SearchModal() {
 
   /** This helper function clears search box and all suggestions */
   const clearSearchModal = () => {
-    setSuggestions([...signedOutRoutes]);
+    setSuggestions([...filteredSignedOutRoutes]);
     setKeyword('');
   };
 
@@ -190,7 +192,7 @@ export default function SearchModal() {
 
     // Return if keyword is blank
     if (!keyword) {
-      setSuggestions([...signedOutRoutes]);
+      setSuggestions([...filteredSignedOutRoutes]);
       return;
     }
 

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -37,23 +37,20 @@ export const notAuthenticatedRoutes = [
     queryParams: {
       redirect: 'redirect',
     },
-    hideFromShortcutSuggestions: false
   },
   {
     Component: ForgotPassword,
     path: '/forgot',
     pageName: 'Forgot Password',
     allowedIf: allowedIf.UNAUTHENTICATED,
-    redirect: '/',
-    hideFromShortcutSuggestions: false
+    redirect: '/'
   },
   {
     Component: MembershipApplication,
     path: '/register',
     pageName: 'Sign Up',
     allowedIf: allowedIf.UNAUTHENTICATED,
-    redirect: '/',
-    hideFromShortcutSuggestions: false
+    redirect: '/'
   },
 ];
 
@@ -63,8 +60,7 @@ const authenticatedRoutes = [
     path: '/profile',
     pageName: 'Profile',
     allowedIf: allowedIf.AUTHENTICATED,
-    redirect: '/login',
-    hideFromShortcutSuggestions: false
+    redirect: '/login'
   },
 ];
 
@@ -74,8 +70,7 @@ export const memberRoutes = [
     path: '/2DPrinting',
     pageName: '2D Printing',
     allowedIf: allowedIf.MEMBER,
-    redirect: '/login',
-    hideFromShortcutSuggestions: false
+    redirect: '/login'
   },
   {
     Component: Messaging,
@@ -97,7 +92,6 @@ export const officerOrAdminRoutes = [
     allowedIf: allowedIf.OFFICER_OR_ADMIN,
     redirect: '/',
     inAdminNavbar: true,
-    hideFromShortcutSuggestions: false
   },
   //
   // {
@@ -114,7 +108,6 @@ export const officerOrAdminRoutes = [
     allowedIf: allowedIf.OFFICER_OR_ADMIN,
     redirect: '/',
     inAdminNavbar: true,
-    hideFromShortcutSuggestions: false
   },
   {
     Component: EditUserInfo,
@@ -132,7 +125,6 @@ export const officerOrAdminRoutes = [
     allowedIf: allowedIf.OFFICER_OR_ADMIN,
     inAdminNavbar: true,
     redirect: '/',
-    hideFromShortcutSuggestions: false
   },
   {
     Component: sendUnsubscribeEmail,
@@ -141,7 +133,6 @@ export const officerOrAdminRoutes = [
     allowedIf: allowedIf.OFFICER_OR_ADMIN,
     inAdminNavbar: true,
     redirect: '/',
-    hideFromShortcutSuggestions: false
   },
   {
     Component: AdvertisementAdmin,
@@ -149,8 +140,7 @@ export const officerOrAdminRoutes = [
     pageName: 'Advertisement Admin',
     allowedIf: allowedIf.OFFICER_OR_ADMIN,
     redirect: '/',
-    inAdminNavbar: true,
-    hideFromShortcutSuggestions: false
+    inAdminNavbar: true
   },
   {
     Component: CardReader,
@@ -158,8 +148,7 @@ export const officerOrAdminRoutes = [
     pageName: 'Card Reader',
     allowedIf: allowedIf.OFFICER_OR_ADMIN,
     redirect: '/',
-    inAdminNavbar: true,
-    hideFromShortcutSuggestions: false
+    inAdminNavbar: true
   },
   {
     Component: AuditLogsPage,
@@ -167,8 +156,7 @@ export const officerOrAdminRoutes = [
     pageName: 'Audit Log',
     allowedIf: allowedIf.OFFICER_OR_ADMIN,
     redirect: '/',
-    inAdminNavbar: true,
-    hideFromShortcutSuggestions: false
+    inAdminNavbar: true
   },
   ...memberRoutes,
 ];
@@ -177,8 +165,7 @@ export const signedOutRoutes = [
   {
     Component: Home,
     path: '/',
-    pageName: 'Home Page',
-    hideFromShortcutSuggestions: false
+    pageName: 'Home Page'
   },
   {
     Component: VerifyEmailPage,
@@ -195,14 +182,12 @@ export const signedOutRoutes = [
   {
     Component: AboutPage,
     path: '/about',
-    pageName: 'About Us',
-    hideFromShortcutSuggestions: false
+    pageName: 'About Us'
   },
   {
     Component: ProjectsPage,
     path: '/projects',
-    pageName: 'Projects',
-    hideFromShortcutSuggestions: false
+    pageName: 'Projects'
   },
   {
     Component: EmailPreferencesPage,

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -37,20 +37,23 @@ export const notAuthenticatedRoutes = [
     queryParams: {
       redirect: 'redirect',
     },
+    hideFromShortcutSuggestions: false
   },
   {
     Component: ForgotPassword,
     path: '/forgot',
     pageName: 'Forgot Password',
     allowedIf: allowedIf.UNAUTHENTICATED,
-    redirect: '/'
+    redirect: '/',
+    hideFromShortcutSuggestions: false
   },
   {
     Component: MembershipApplication,
     path: '/register',
     pageName: 'Sign Up',
     allowedIf: allowedIf.UNAUTHENTICATED,
-    redirect: '/'
+    redirect: '/',
+    hideFromShortcutSuggestions: false
   },
 ];
 
@@ -60,7 +63,8 @@ const authenticatedRoutes = [
     path: '/profile',
     pageName: 'Profile',
     allowedIf: allowedIf.AUTHENTICATED,
-    redirect: '/login'
+    redirect: '/login',
+    hideFromShortcutSuggestions: false
   },
 ];
 
@@ -70,14 +74,16 @@ export const memberRoutes = [
     path: '/2DPrinting',
     pageName: '2D Printing',
     allowedIf: allowedIf.MEMBER,
-    redirect: '/login'
+    redirect: '/login',
+    hideFromShortcutSuggestions: false
   },
   {
     Component: Messaging,
     path: '/messaging/:id?',
     pageName: 'Messaging',
     allowedIf: allowedIf.MEMBER,
-    redirect: '/login'
+    redirect: '/login',
+    hideFromShortcutSuggestions: true
   },
   ...authenticatedRoutes,
 ];
@@ -90,7 +96,8 @@ export const officerOrAdminRoutes = [
     pageName: 'User Manager',
     allowedIf: allowedIf.OFFICER_OR_ADMIN,
     redirect: '/',
-    inAdminNavbar: true
+    inAdminNavbar: true,
+    hideFromShortcutSuggestions: false
   },
   //
   // {
@@ -106,7 +113,8 @@ export const officerOrAdminRoutes = [
     pageName: 'LED Sign',
     allowedIf: allowedIf.OFFICER_OR_ADMIN,
     redirect: '/',
-    inAdminNavbar: true
+    inAdminNavbar: true,
+    hideFromShortcutSuggestions: false
   },
   {
     Component: EditUserInfo,
@@ -114,7 +122,8 @@ export const officerOrAdminRoutes = [
     pageName: 'Edit User Info',
     allowedIf: allowedIf.OFFICER_OR_ADMIN,
     redirect: '/',
-    inAdminNavbar: true
+    inAdminNavbar: true,
+    hideFromShortcutSuggestions: true
   },
   {
     Component: URLShortenerPage,
@@ -123,6 +132,7 @@ export const officerOrAdminRoutes = [
     allowedIf: allowedIf.OFFICER_OR_ADMIN,
     inAdminNavbar: true,
     redirect: '/',
+    hideFromShortcutSuggestions: false
   },
   {
     Component: sendUnsubscribeEmail,
@@ -131,6 +141,7 @@ export const officerOrAdminRoutes = [
     allowedIf: allowedIf.OFFICER_OR_ADMIN,
     inAdminNavbar: true,
     redirect: '/',
+    hideFromShortcutSuggestions: false
   },
   {
     Component: AdvertisementAdmin,
@@ -138,7 +149,8 @@ export const officerOrAdminRoutes = [
     pageName: 'Advertisement Admin',
     allowedIf: allowedIf.OFFICER_OR_ADMIN,
     redirect: '/',
-    inAdminNavbar: true
+    inAdminNavbar: true,
+    hideFromShortcutSuggestions: false
   },
   {
     Component: CardReader,
@@ -146,7 +158,8 @@ export const officerOrAdminRoutes = [
     pageName: 'Card Reader',
     allowedIf: allowedIf.OFFICER_OR_ADMIN,
     redirect: '/',
-    inAdminNavbar: true
+    inAdminNavbar: true,
+    hideFromShortcutSuggestions: false
   },
   {
     Component: AuditLogsPage,
@@ -154,7 +167,8 @@ export const officerOrAdminRoutes = [
     pageName: 'Audit Log',
     allowedIf: allowedIf.OFFICER_OR_ADMIN,
     redirect: '/',
-    inAdminNavbar: true
+    inAdminNavbar: true,
+    hideFromShortcutSuggestions: false
   },
   ...memberRoutes,
 ];
@@ -163,31 +177,37 @@ export const signedOutRoutes = [
   {
     Component: Home,
     path: '/',
-    pageName: 'Home Page'
+    pageName: 'Home Page',
+    hideFromShortcutSuggestions: false
   },
   {
     Component: VerifyEmailPage,
     path: '/verify',
-    pageName: 'Verify Email'
+    pageName: 'Verify Email',
+    hideFromShortcutSuggestions: true
   },
   {
     Component: ResetPasswordPage,
     path: '/reset',
-    pageName: 'Reset Password'
+    pageName: 'Reset Password',
+    hideFromShortcutSuggestions: true
   },
   {
     Component: AboutPage,
     path: '/about',
-    pageName: 'About Us'
+    pageName: 'About Us',
+    hideFromShortcutSuggestions: false
   },
   {
     Component: ProjectsPage,
     path: '/projects',
-    pageName: 'Projects'
+    pageName: 'Projects',
+    hideFromShortcutSuggestions: false
   },
   {
     Component: EmailPreferencesPage,
     path: '/emailPreferences',
-    pageName: 'Email Preferences'
+    pageName: 'Email Preferences',
+    hideFromShortcutSuggestions: true
   },
 ];

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -103,7 +103,7 @@ export const officerOrAdminRoutes = [
   {
     Component: LedSign,
     path: '/led-sign',
-    pageName: 'Led Sign',
+    pageName: 'LED Sign',
     allowedIf: allowedIf.OFFICER_OR_ADMIN,
     redirect: '/',
     inAdminNavbar: true


### PR DESCRIPTION
Search bar will no longer show pages: Reset Password, Verify Email, Email Preferences

Screenshots:
<img width="1919" height="1026" alt="image" src="https://github.com/user-attachments/assets/9eef2c3f-604d-4f2d-9311-1eaf60c0bef8" />

============================================================

<img width="1919" height="1022" alt="image" src="https://github.com/user-attachments/assets/995f1f02-447e-4628-9826-67163abecd88" />

