### PR TITLE
add FORBIDDEN to token stub tests

### DIFF
--- a/api/main_endpoints/routes/Printer.js
+++ b/api/main_endpoints/routes/Printer.js
@@ -74,7 +74,7 @@ router.get('/healthCheck', async (req, res) => {
 
 router.post('/sendPrintRequest', upload.single('chunk'), async (req, res) => {
   const decoded = await decodeToken(req);
-  if (!decoded.token) {
+  if (decoded.status !== OK) {
     logger.warn('/sendPrintRequest was requested with an invalid token');
     return res.sendStatus(decoded.status);
   }
@@ -150,8 +150,8 @@ router.post('/sendPrintRequest', upload.single('chunk'), async (req, res) => {
 });
 
 router.get('/status', async (req, res) => {
-  const decodedToken = await decodeToken(req);
-  if (!decodedToken || Object.keys(decodedToken) === 0) {
+  const decodeToken = await decodeToken(req);
+  if (decodeToken.status !== OK) {
     logger.warn('/status was requested with an invalid token');
     return res.sendStatus(UNAUTHORIZED);
   }

--- a/api/main_endpoints/routes/Printer.js
+++ b/api/main_endpoints/routes/Printer.js
@@ -150,8 +150,8 @@ router.post('/sendPrintRequest', upload.single('chunk'), async (req, res) => {
 });
 
 router.get('/status', async (req, res) => {
-  const decodeToken = await decodeToken(req);
-  if (decodeToken.status !== OK) {
+  const decoded = await decodeToken(req);
+  if (decoded.status !== OK) {
     logger.warn('/status was requested with an invalid token');
     return res.sendStatus(UNAUTHORIZED);
   }

--- a/api/main_endpoints/routes/ShortcutSearch.js
+++ b/api/main_endpoints/routes/ShortcutSearch.js
@@ -6,8 +6,6 @@ const User = require('../models/User.js');
 const { decodeToken } = require('../util/token-functions');
 const {
   OK,
-  UNAUTHORIZED,
-  FORBIDDEN,
   SERVER_ERROR,
 } = require('../../util/constants').STATUS_CODES;
 const membershipState = require('../../util/constants').MEMBERSHIP_STATE;
@@ -21,7 +19,7 @@ const MAX_RESULT = 5;
 // Search for all cleezy urls using either alias or url
 router.post('/', async function(req, res) {
   const decoded = await decodeToken(req, membershipState.OFFICER);
-  if (!decoded.token) {
+  if (decoded.status !== OK) {
     return res.sendStatus(decoded.status);
   }
 

--- a/api/main_endpoints/routes/User.js
+++ b/api/main_endpoints/routes/User.js
@@ -33,7 +33,7 @@ const ROWS_PER_PAGE = 20;
 // Delete a member
 router.post('/delete', async (req, res) => {
   const decoded = await decodeToken(req);
-  if (!decoded.token) {
+  if (decoded.status !== OK) {
     return res.sendStatus(decoded.status);
   }
 
@@ -76,8 +76,7 @@ router.post('/delete', async (req, res) => {
 // Search for a member
 router.post('/search', async function(req, res) {
   const decoded = await decodeToken(req, membershipState.OFFICER);
-
-  if (!decoded.token) {
+  if (decoded.status !== OK) {
     return res.sendStatus(decoded.status);
   }
 
@@ -119,7 +118,7 @@ router.post('/search', async function(req, res) {
 // Search for all members
 router.post('/users', async function(req, res) {
   const decoded = await decodeToken(req, membershipState.OFFICER);
-  if (!decoded.token) {
+  if (decoded.status !== OK) {
     return res.sendStatus(decoded.status);
   }
 
@@ -162,7 +161,7 @@ router.post('/users', async function(req, res) {
 // Edit/Update a member record
 router.post('/edit', async (req, res) => {
   const decoded = await decodeToken(req);
-  if (!decoded.token) {
+  if (decoded.status !== OK) {
     return res.sendStatus(decoded.status);
   }
 
@@ -291,7 +290,7 @@ router.post('/edit', async (req, res) => {
 
 router.post('/getPagesPrintedCount', async (req, res) => {
   const decoded = await decodeToken(req);
-  if (!decoded.token) {
+  if (decoded.status !== OK) {
     return res.sendStatus(decoded.status);
   }
   User.findOne({ email: req.body.email }, function(error, result) {
@@ -317,7 +316,7 @@ router.post('/getPagesPrintedCount', async (req, res) => {
 
 router.post('/getUserById', async (req, res) => {
   const decoded = await decodeToken(req);
-  if (!decoded.token) {
+  if (decoded.status !== OK) {
     return res.sendStatus(decoded.status);
   }
   let targetUserId = req.body.userID;
@@ -403,7 +402,7 @@ router.post('/getUserDataByEmail', (req, res) => {
 // Search for all members with verified emails and subscribed
 router.post('/usersSubscribedAndVerified', async function(req, res) {
   const decoded = await decodeToken(req, membershipState.OFFICER);
-  if (!decoded.token) {
+  if (decoded.status !== OK) {
     return res.sendStatus(decoded.status);
   }
   User.find({ emailVerified: true, emailOptIn: true })
@@ -428,7 +427,7 @@ router.post('/usersSubscribedAndVerified', async function(req, res) {
 // Search for all members with verified emails, subscribed, and not banned or pending
 router.post('/usersValidVerifiedAndSubscribed', async function(req, res) {
   const decoded = await decodeToken(req, membershipState.OFFICER);
-  if (!decoded.token) {
+  if (decoded.status !== OK) {
     return res.sendStatus(decoded.status);
   }
   User.find({
@@ -454,7 +453,7 @@ router.post('/usersValidVerifiedAndSubscribed', async function(req, res) {
 // Generate an API key for the Messages API if the user does not have an API key; otherwise, return the existing API key
 router.post('/apikey', async (req, res) => {
   const decoded = await decodeToken(req);
-  if (!decoded.token) {
+  if (decoded.status !== OK) {
     return res.sendStatus(decoded.status);
   }
   let { _id } = decoded.token;
@@ -488,7 +487,7 @@ router.post('/apikey', async (req, res) => {
 //  Assumes members who have paid have been assigned an expiration date
 router.get('/getNewPaidMembersThisSemester', async (req, res) => {
   const decoded = await decodeToken(req, membershipState.OFFICER);
-  if (!decoded.token) {
+  if (decoded.status !== OK) {
     return res.sendStatus(decoded.status);
   }
 

--- a/test/api/Advertisement.js
+++ b/test/api/Advertisement.js
@@ -66,9 +66,10 @@ describe('Advertisement', () => {
       expect(res).to.have.status(UNAUTHORIZED);
     });
 
-    it('Should return 401 when invalid token is sent', async () => {
+    it('Should return 403 when invalid token is sent', async () => {
+      setTokenStatus(null);
       const res = await test.sendPostRequestWithToken(token, '/api/Advertisement/createAdvertisement', VALID_ADVERTISEMENT);
-      expect(res).to.have.status(UNAUTHORIZED);
+      expect(res).to.have.status(FORBIDDEN);
     });
 
     describe('audit log tests for creating ads', () => {
@@ -130,9 +131,10 @@ describe('Advertisement', () => {
       expect(res).to.have.status(UNAUTHORIZED);
     });
 
-    it('Should return 401 if invalid token is sent', async () => {
+    it('Should return 403 if invalid token is sent', async () => {
+      setTokenStatus(null);
       const res = await test.sendPostRequestWithToken(token, '/api/Advertisement/deleteAdvertisement', { _id: VALID_ADVERTISEMENT._id });
-      expect(res).to.have.status(UNAUTHORIZED);
+      expect(res).to.have.status(FORBIDDEN);
     });
 
     it('Should return 404 if ad is not found', async () => {

--- a/test/api/Auth.js
+++ b/test/api/Auth.js
@@ -13,7 +13,8 @@ const {
   OK,
   BAD_REQUEST,
   UNAUTHORIZED,
-  CONFLICT
+  CONFLICT,
+  FORBIDDEN
 } = require('../../api/util/constants').STATUS_CODES;
 const SceApiTester = require('../util/tools/SceApiTester');
 

--- a/test/api/Auth.js
+++ b/test/api/Auth.js
@@ -562,11 +562,12 @@ describe('Auth', () => {
         expect(result).to.have.status(UNAUTHORIZED);
       });
 
-    it('Should return statusCode 401 when a token is invalid',
+    it('Should return statusCode 403 when a token is invalid',
       async () => {
+        setTokenStatus(null);
         const result = await test.sendPostRequestWithToken(
           token, '/api/Auth/verify', {});
-        expect(result).to.have.status(UNAUTHORIZED);
+        expect(result).to.have.status(FORBIDDEN);
       });
 
     it('Should return statusCode 200 when a ' +

--- a/test/api/LedSign.js
+++ b/test/api/LedSign.js
@@ -9,6 +9,7 @@ const {
   OK,
   SERVER_ERROR,
   UNAUTHORIZED,
+  FORBIDDEN
 } = require('../../api/util/constants').STATUS_CODES;
 const {
   initializeTokenMock,
@@ -67,15 +68,16 @@ describe('LED Sign', () => {
   });
 
   describe('/POST updateSignText', () => {
-    it('Should return 400 when token is not sent', async () => {
+    it('Should return 401 when token is not sent', async () => {
       const result = await test.sendPostRequest('/api/LedSign/updateSignText');
       expect(result).to.have.status(UNAUTHORIZED);
     });
 
-    it('Should return 400 when invalid token is sent', async () => {
+    it('Should return 403 when invalid token is sent', async () => {
+      setTokenStatus(null);
       const result = await test.sendPostRequestWithToken(token,
         '/api/LedSign/updateSignText');
-      expect(result).to.have.status(UNAUTHORIZED);
+      expect(result).to.have.status(FORBIDDEN);
     });
 
     it('Should return 500 when the ssh tunnel is down', async () => {

--- a/test/api/OfficeAccessCard.js
+++ b/test/api/OfficeAccessCard.js
@@ -222,20 +222,20 @@ describe('OfficeAccessCard', () => {
 
   describe('POST getAllCards', () => {
     it('Should return 401 when token is not sent', async () => {
-      const result = await test.sendGetRequest(GET_ALL_CARDS_API_PATH);
+      const result = await test.sendPostRequest(GET_ALL_CARDS_API_PATH);
       expect(result).to.have.status(UNAUTHORIZED);
     });
 
     it('Should return 403 when invalid token is sent', async () => {
       setTokenStatus(null);
-      const result = await test.sendGetRequestWithToken(token,
+      const result = await test.sendPostRequestWithToken(token,
         GET_ALL_CARDS_API_PATH);
       expect(result).to.have.status(FORBIDDEN);
     });
 
     it('Should return 200 with a successful fetch of all cards', async () => {
       setTokenStatus(true);
-      const result = await test.sendGetRequestWithToken(token,
+      const result = await test.sendPostRequestWithToken(token,
         GET_ALL_CARDS_API_PATH,
       );
       expect(result).to.have.status(OK);
@@ -244,7 +244,7 @@ describe('OfficeAccessCard', () => {
     it('Should return 500 if there was an error fetching all cards', async () => {
       setTokenStatus(true);
       const findStub = sinon.stub(OfficeAccessCard, 'find').rejects(new Error('Database error'));
-      const result = await test.sendGetRequestWithToken(token,
+      const result = await test.sendPostRequestWithToken(token,
         GET_ALL_CARDS_API_PATH,
       );
       expect(result).to.have.status(SERVER_ERROR);

--- a/test/api/OfficeAccessCard.js
+++ b/test/api/OfficeAccessCard.js
@@ -256,10 +256,11 @@ describe('OfficeAccessCard', () => {
       expect(result).to.have.status(UNAUTHORIZED);
     });
 
-    it('Should return 401 when invalid token is sent', async () => {
+    it('Should return 403 when invalid token is sent', async () => {
+      setTokenStatus(null);
       const result = await test.sendPostRequestWithToken(token,
-        EDIT_API_PATH);
-      expect(result).to.have.status(UNAUTHORIZED);
+        EDIT_API_PATH, { _id: testCardId, alias: NEW_ALIAS });
+      expect(result).to.have.status(FORBIDDEN);
     });
 
     it('Should return 400 when _id is missing from request body', async () => {

--- a/test/api/OfficeAccessCard.js
+++ b/test/api/OfficeAccessCard.js
@@ -185,10 +185,11 @@ describe('OfficeAccessCard', () => {
       expect(result).to.have.status(UNAUTHORIZED);
     });
 
-    it('Should return 401 when invalid token is sent', async () => {
+    it('Should return 403 when invalid token is sent', async () => {
+      setTokenStatus(null);
       const result = await test.sendPostRequestWithToken(token,
-        DELETE_API_PATH);
-      expect(result).to.have.status(UNAUTHORIZED);
+        DELETE_API_PATH, { _id: VALID_ID });
+      expect(result).to.have.status(FORBIDDEN);
     });
 
     it('Should return 404 if the card attempted to be deleted was not found', async () => {
@@ -221,19 +222,20 @@ describe('OfficeAccessCard', () => {
 
   describe('POST getAllCards', () => {
     it('Should return 401 when token is not sent', async () => {
-      const result = await test.sendPostRequest(GET_ALL_CARDS_API_PATH);
+      const result = await test.sendGetRequest(GET_ALL_CARDS_API_PATH);
       expect(result).to.have.status(UNAUTHORIZED);
     });
 
-    it('Should return 401 when invalid token is sent', async () => {
-      const result = await test.sendPostRequestWithToken(token,
+    it('Should return 403 when invalid token is sent', async () => {
+      setTokenStatus(null);
+      const result = await test.sendGetRequestWithToken(token,
         GET_ALL_CARDS_API_PATH);
-      expect(result).to.have.status(UNAUTHORIZED);
+      expect(result).to.have.status(FORBIDDEN);
     });
 
     it('Should return 200 with a successful fetch of all cards', async () => {
       setTokenStatus(true);
-      const result = await test.sendPostRequestWithToken(token,
+      const result = await test.sendGetRequestWithToken(token,
         GET_ALL_CARDS_API_PATH,
       );
       expect(result).to.have.status(OK);
@@ -242,7 +244,7 @@ describe('OfficeAccessCard', () => {
     it('Should return 500 if there was an error fetching all cards', async () => {
       setTokenStatus(true);
       const findStub = sinon.stub(OfficeAccessCard, 'find').rejects(new Error('Database error'));
-      const result = await test.sendPostRequestWithToken(token,
+      const result = await test.sendGetRequestWithToken(token,
         GET_ALL_CARDS_API_PATH,
       );
       expect(result).to.have.status(SERVER_ERROR);

--- a/test/api/Printer.js
+++ b/test/api/Printer.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const {
   OK,
   UNAUTHORIZED,
+  FORBIDDEN,
 } = require('../../api/util/constants').STATUS_CODES;
 
 const {
@@ -116,14 +117,15 @@ describe('Printer', () => {
 
     const DUMMY_CHUNK = new FormData();
 
-    it('Should return 400 when token is not sent', async () => {
+    it('Should return 401 when token is not sent', async () => {
       const result = await test.sendPostRequest('/api/Printer/sendPrintRequest', { DUMMY_CHUNK });
       expect(result).to.have.status(UNAUTHORIZED);
     });
 
-    it('Should return 400 when invalid token is sent', async () => {
+    it('Should return 403 when invalid token is sent', async () => {
+      setTokenStatus(null);
       const result = await test.sendPostRequestWithToken(token, '/api/Printer/sendPrintRequest', { DUMMY_CHUNK });
-      expect(result).to.have.status(UNAUTHORIZED);
+      expect(result).to.have.status(FORBIDDEN);
     });
 
     it(`Should successfully process all ${TOTAL_CHUNKS} chunks sent (with valid token)`, async () => {

--- a/test/api/ShortcutSearch.js
+++ b/test/api/ShortcutSearch.js
@@ -9,6 +9,7 @@ const chaiHttp = require('chai-http');
 const {
   OK,
   UNAUTHORIZED,
+  FORBIDDEN,
 } = require('../../api/util/constants').STATUS_CODES;
 const SceApiTester = require('../util/tools/SceApiTester');
 
@@ -76,10 +77,10 @@ describe('ShortcutSearch', () => {
       expect(result).to.have.status(UNAUTHORIZED);
     });
 
-    it('Should return status code 401 if access level is invalid', async () => {
-      setTokenStatus(false, { accessLevel: MEMBERSHIP_STATE.MEMBER });
+    it('Should return status code 403 if access level is invalid', async () => {
+      setTokenStatus(null, { accessLevel: MEMBERSHIP_STATE.MEMBER });
       const result = await test.sendPostRequestWithToken(token, url, queryUser);
-      expect(result).to.have.status(UNAUTHORIZED);
+      expect(result).to.have.status(FORBIDDEN);
     });
 
     before(async () => {

--- a/test/api/User.js
+++ b/test/api/User.js
@@ -89,14 +89,15 @@ describe('User', () => {
       expect(result).to.have.status(UNAUTHORIZED);
     });
 
-    it('Should return statusCode 401 if an invalid ' +
+    it('Should return statusCode 403 if an invalid ' +
       'token was passed in', async () => {
       const user = {
         token: 'Invalid token'
       };
+      setTokenStatus(null);
       const result = await test.sendPostRequestWithToken(
         token, '/api/User/users', user);
-      expect(result).to.have.status(UNAUTHORIZED);
+      expect(result).to.have.status(FORBIDDEN);
     });
 
     it('Should return statusCode 200 and return an array ' +
@@ -122,15 +123,16 @@ describe('User', () => {
       expect(result).to.have.status(UNAUTHORIZED);
     });
 
-    it('Should return statusCode 401 if an invalid ' +
+    it('Should return statusCode 403 if an invalid ' +
       'token was passed in', async () => {
       const user = {
         email: 'a@b.c',
         token: 'Invalid token'
       };
+      setTokenStatus(null);
       const result = await test.sendPostRequestWithToken(
         token, '/api/User/search', user);
-      expect(result).to.have.status(UNAUTHORIZED);
+      expect(result).to.have.status(FORBIDDEN);
     });
 
     it('Should return statusCode 404 if no user was found', async () => {
@@ -178,15 +180,16 @@ describe('User', () => {
       expect(result).to.have.status(UNAUTHORIZED);
     });
 
-    it('Should return statusCode 401 if an invalid ' +
+    it('Should return statusCode 403 if an invalid ' +
       'token was passed in', async () => {
       const user = {
         email: 'a@b.c',
         token: 'Invalid token'
       };
+      setTokenStatus(null);
       const result = await test.sendPostRequestWithToken(
         token, '/api/User/edit', user);
-      expect(result).to.have.status(UNAUTHORIZED);
+      expect(result).to.have.status(FORBIDDEN);
     });
 
     it('Should return statusCode 404 if no user was found', async () => {
@@ -366,14 +369,15 @@ describe('User', () => {
       const result = await test.sendPostRequest('/api/user/getUserById', user);
       expect(result).to.have.status(UNAUTHORIZED);
     });
-    it('Should return status code 401 if' +
+    it('Should return status code 403 if' +
       ' an invalid token was passed in', async () => {
       const user = {
         userID: id,
         token: 'Invalid Token'
       };
+      setTokenStatus(null);
       const result = await test.sendPostRequestWithToken(token, '/api/user/getUserById', user);
-      expect(result).to.have.status(UNAUTHORIZED);
+      expect(result).to.have.status(FORBIDDEN);
     });
     it('Should return status code 404 if user is not found', async () => {
       const user = {
@@ -444,9 +448,10 @@ describe('User', () => {
         _id: id,
         token: 'Invalid token'
       };
+      setTokenStatus(null);
       const result = await test.sendPostRequestWithToken(
         token, '/api/User/delete', user);
-      expect(result).to.have.status(UNAUTHORIZED);
+      expect(result).to.have.status(FORBIDDEN);
     });
 
     it('Should return statusCode 404 if no user was found', async () => {
@@ -618,15 +623,16 @@ describe('User', () => {
     });
 
     // invalid token
-    it('Should return statusCode 401 if an invalid ' +
+    it('Should return statusCode 403 if an invalid ' +
       'token was passed in', async () => {
       const user = {
         _id: id,
         token: 'Invalid token'
       };
+      setTokenStatus(null);
       const result = await test.sendPostRequestWithToken(
         token, '/api/User/apikey', user);
-      expect(result).to.have.status(UNAUTHORIZED);
+      expect(result).to.have.status(FORBIDDEN);
     });
   });
 
@@ -642,11 +648,11 @@ describe('User', () => {
       expect(result).to.have.status(UNAUTHORIZED);
     });
 
-    it('Should return statusCode 401 if an invalid' +
+    it('Should return statusCode 403 if an invalid' +
       'token was passed in', async () => {
-      setTokenStatus(false);
+      setTokenStatus(null);
       const result = await test.sendGetRequestWithToken(token, '/api/user/getNewPaidMembersThisSemester');
-      expect(result).to.have.status(UNAUTHORIZED);
+      expect(result).to.have.status(FORBIDDEN);
     });
 
     describe('1st Semester Mock Test', () => {

--- a/test/util/mocks/TokenValidFunctions.js
+++ b/test/util/mocks/TokenValidFunctions.js
@@ -28,18 +28,32 @@ function resetTokenMock() {
 
 /**
  *
- * @param {any} returnValue: value to be return back
- *                           by the function 'checkIfTokenValid'
+ * @param {boolean|null} isSuccessful:
+ *    if true, token is valid (status OK),
+ *    if false, token is invalid (status UNAUTHORIZED),
+ *    if null, token is FORBIDDEN
+ *         
  * @param {Object} data: optional value that will be the result
  *                       of the decoded token value
- * @returns return parameter (above)
+ * @returns configured mock response
  */
 function setTokenStatus(
   isSuccessful,
   data = {},
 ) {
-  const status = isSuccessful ? OK : UNAUTHORIZED;
-  const tokenPayload = isSuccessful ? data : null;
+  let status;
+  let tokenPayload;
+  
+  if (isSuccessful === true) {
+    status = OK;
+    tokenPayload = data;
+  } else if (isSuccessful === false) {
+    status = UNAUTHORIZED;
+    tokenPayload = null;
+  } else {
+    status = FORBIDDEN;
+    tokenPayload = data;
+  }
 
   decodeTokenValidMock.returns(
     Promise.resolve({

--- a/test/util/mocks/TokenValidFunctions.js
+++ b/test/util/mocks/TokenValidFunctions.js
@@ -32,7 +32,7 @@ function resetTokenMock() {
  *    if true, token is valid (status OK),
  *    if false, token is invalid (status UNAUTHORIZED),
  *    if null, token is FORBIDDEN
- *         
+ *
  * @param {Object} data: optional value that will be the result
  *                       of the decoded token value
  * @returns configured mock response
@@ -43,7 +43,7 @@ function setTokenStatus(
 ) {
   let status;
   let tokenPayload;
-  
+
   if (isSuccessful === true) {
     status = OK;
     tokenPayload = data;


### PR DESCRIPTION
right now we can only stub tokens to be good (OK) or bad (UNAUTHORIZED), which ignores the possibility that a token is valid but possesses invalid access level (FORBIDDEN would be expected here). this PR allows for tokens to be mocked to return FORBIDDEN status