### PR TITLE
Add SCEvents Landing Page

### DIFF
--- a/src/APIFunctions/SCEvents.js
+++ b/src/APIFunctions/SCEvents.js
@@ -1,0 +1,34 @@
+import { ApiResponse } from './ApiResponses';
+
+/*
+  #2067:
+  Clark should communicate with a locally running SCEvents instance.
+  From SCEvents/cmd/server/main.go, local GET /events/ is exposed by Gin.
+*/
+const SCEVENTS_API_URL = 'http://localhost:8080';
+
+export async function getAllSCEvents() {
+  let status = new ApiResponse();
+
+  try {
+    const url = new URL('/events/', SCEVENTS_API_URL);
+    const res = await fetch(url.href, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (res.ok) {
+      const result = await res.json();
+      status.responseData = result;
+    } else {
+      status.error = true;
+    }
+  } catch (err) {
+    status.error = true;
+    status.responseData = err;
+  }
+
+  return status;
+}

--- a/src/APIFunctions/SCEvents.js
+++ b/src/APIFunctions/SCEvents.js
@@ -1,10 +1,5 @@
 import { ApiResponse } from './ApiResponses';
 
-/*
-  #2067:
-  Clark should communicate with a locally running SCEvents instance.
-  From SCEvents/cmd/server/main.go, local GET /events/ is exposed by Gin.
-*/
 const SCEVENTS_API_URL = 'http://localhost:8080';
 
 export async function getAllSCEvents() {

--- a/src/Pages/Events/Events.js
+++ b/src/Pages/Events/Events.js
@@ -1,8 +1,106 @@
-
+import React, { useEffect, useState } from 'react';
 import config from '../../config/config.json';
-import NotFoundPage from '../NotFoundPage/NotFoundPage.js';
 import { Redirect } from 'react-router-dom';
+import { getAllSCEvents } from '../../APIFunctions/SCEvents';
+
+
+function EventCard({ event }) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/5 p-6 shadow-md transition hover:scale-[1.02]">
+      <h2 className="mb-4 text-2xl font-bold text-white">
+        {event.name || 'Untitled Event'}
+      </h2>
+
+      <div className="mb-4 space-y-2 text-blue-300">
+        {event.date && <p className="text-lg">{event.date}</p>}
+        {event.time && <p className="text-lg">{event.time}</p>}
+        {event.location && <p className="text-lg">{event.location}</p>}
+      </div>
+
+      {event.description && (
+        <p className="text-base leading-7 text-gray-300">
+          {event.description}
+        </p>
+      )}
+    </div>
+  );
+}
 
 export default function EventsPage() {
-  return config.SCEvents.ENABLED ? <h1>Events Page</h1> : <Redirect to="/notfound" />;
+  const [events, setEvents] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+  const isSCEventsEnabled = config.SCEvents?.ENABLED;
+
+  useEffect(() => {
+    if (!isSCEventsEnabled) {
+      return;
+    }
+
+    async function fetchEvents() {
+      setIsLoading(true);
+      setHasError(false);
+
+      const response = await getAllSCEvents();
+
+      if (!response.error) {
+        setEvents(Array.isArray(response.responseData) ? response.responseData : []);
+      } else {
+        setHasError(true);
+      }
+
+      setIsLoading(false);
+    }
+
+    fetchEvents();
+  }, [isSCEventsEnabled]);
+
+  if (!isSCEventsEnabled) {
+    return <Redirect to="/notfound" />;
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-r from-gray-800 to-gray-600 text-white">
+      <div className="mx-auto max-w-6xl px-6 py-12">
+        <h1 className="mb-3 text-4xl font-bold text-white md:text-5xl">
+          SCEvents
+        </h1>
+        <div className="mb-6 h-1 w-24 bg-blue-400"></div>
+        <p className="max-w-2xl text-lg text-gray-300 md:text-xl">
+          Discover upcoming SCE events and activities.
+        </p>
+      </div>
+
+      <div className="mx-auto max-w-6xl px-6 pb-14">
+        {isLoading && (
+          <div className="py-16 text-center text-lg text-gray-300">
+            Loading events...
+          </div>
+        )}
+
+        {!isLoading && hasError && (
+          <div className="rounded-2xl border border-red-400/30 bg-red-500/10 p-6 text-center text-lg text-red-100">
+            Failed to load events. Please make sure SCEvents is running locally.
+          </div>
+        )}
+
+        {!isLoading && !hasError && events.length === 0 && (
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-10 text-center text-lg text-gray-300">
+            No events available right now.
+          </div>
+        )}
+
+        {!isLoading && !hasError && events.length > 0 && (
+          <div className="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
+            {events.map((event) => (
+              <EventCard
+                key={event.id}
+                event={event}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
 }

--- a/src/Pages/Events/Events.js
+++ b/src/Pages/Events/Events.js
@@ -3,18 +3,67 @@ import config from '../../config/config.json';
 import { Redirect } from 'react-router-dom';
 import { getAllSCEvents } from '../../APIFunctions/SCEvents';
 
+function CalendarIcon() {
+  return (
+    <svg
+      className="h-4 w-4 flex-shrink-0"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      aria-hidden="true"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M8 2v4M16 2v4M3 10h18" />
+      <rect x="3" y="4" width="18" height="17" rx="2" />
+    </svg>
+  );
+}
+
+function PinIcon() {
+  return (
+    <svg
+      className="h-4 w-4 flex-shrink-0"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 21s6-5.686 6-11a6 6 0 1 0-12 0c0 5.314 6 11 6 11Z"
+      />
+      <circle cx="12" cy="10" r="2.5" />
+    </svg>
+  );
+}
 
 function EventCard({ event }) {
   return (
-    <div className="rounded-2xl border border-white/10 bg-white/5 p-6 shadow-md transition hover:scale-[1.02]">
+    <div className="group rounded-2xl border border-white/10 bg-white/5 p-6 shadow-md backdrop-blur-sm transition duration-300 hover:-translate-y-1 hover:border-white/20 hover:bg-white/[0.07]">
       <h2 className="mb-4 text-2xl font-bold text-white">
         {event.name || 'Untitled Event'}
       </h2>
 
-      <div className="mb-4 space-y-2 text-blue-300">
-        {event.date && <p className="text-lg">{event.date}</p>}
-        {event.time && <p className="text-lg">{event.time}</p>}
-        {event.location && <p className="text-lg">{event.location}</p>}
+      <div className="mb-5 space-y-2 text-sm text-gray-300">
+        {(event.date || event.time) && (
+          <div className="flex items-center gap-2">
+            <span className="text-blue-300">
+              <CalendarIcon />
+            </span>
+            <span>{[event.date, event.time].filter(Boolean).join(' · ')}</span>
+          </div>
+        )}
+
+        {event.location && (
+          <div className="flex items-center gap-2">
+            <span className="text-blue-300">
+              <PinIcon />
+            </span>
+            <span>{event.location}</span>
+          </div>
+        )}
       </div>
 
       {event.description && (
@@ -60,18 +109,25 @@ export default function EventsPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-r from-gray-800 to-gray-600 text-white">
-      <div className="mx-auto max-w-6xl px-6 py-12">
+    <div className="relative min-h-screen overflow-hidden bg-gradient-to-r from-gray-800 to-gray-600 text-white">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -top-24 left-[-8rem] h-[22rem] w-[22rem] rounded-full bg-sky-400/10 blur-3xl" />
+        <div className="absolute right-[-8rem] top-[10rem] h-[24rem] w-[24rem] rounded-full bg-indigo-500/10 blur-3xl" />
+      </div>
+
+      <div className="relative mx-auto max-w-6xl px-6 py-12">
         <h1 className="mb-3 text-4xl font-bold text-white md:text-5xl">
           SCEvents
         </h1>
-        <div className="mb-6 h-1 w-24 bg-blue-400"></div>
+
+        <div className="mb-6 h-[2px] w-28 rounded-full bg-gradient-to-r from-sky-400 via-blue-400 to-indigo-400" />
+
         <p className="max-w-2xl text-lg text-gray-300 md:text-xl">
           Discover upcoming SCE events and activities.
         </p>
       </div>
 
-      <div className="mx-auto max-w-6xl px-6 pb-14">
+      <div className="relative mx-auto max-w-6xl px-6 pb-14">
         {isLoading && (
           <div className="py-16 text-center text-lg text-gray-300">
             Loading events...
@@ -93,10 +149,7 @@ export default function EventsPage() {
         {!isLoading && !hasError && events.length > 0 && (
           <div className="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
             {events.map((event) => (
-              <EventCard
-                key={event.id}
-                event={event}
-              />
+              <EventCard key={event.id} event={event} />
             ))}
           </div>
         )}


### PR DESCRIPTION
issue #2067 

### Summary

* Implemented `/events` page in Clark
* Fetches events from SCEvents backend (`GET /events`)
* Displays events in a responsive card grid
* Feature-gated behind `SCEvents.ENABLED`

### Features

* Loading / error / empty states
* Event metadata (date, time, location)
* Responsive layout (1/2/3 columns)
* Uses existing Clark styling patterns

### Notes

* Event creation and registration flows are intentionally excluded (handled in #2068)
* Verified locally with SCEvents running and real data

### Testing

* Tested with SCEvents running locally
* feature flag OFF
<img width="1920" height="933" alt="Screenshot 2026-03-31 at 11 50 09 PM" src="https://github.com/user-attachments/assets/e6a0e31e-3080-4f09-87e3-06c3eb50569e" />

When `SCEvents.ENABLED = false`, navigating to `/events` redirects to the NotFound page.
<img width="1920" height="932" alt="Screenshot 2026-04-01 at 1 40 52 AM" src="https://github.com/user-attachments/assets/cbaa7226-4d7e-4a1b-a5ae-02feaa4df34a" />

* feature flag ON
<img width="1920" height="933" alt="Screenshot 2026-03-31 at 11 51 45 PM" src="https://github.com/user-attachments/assets/22c2d644-2b80-464f-936a-2fa4f5f80010" />

* loading state
<img width="1920" height="933" alt="Screenshot 2026-04-01 at 12 01 13 AM" src="https://github.com/user-attachments/assets/b38807ae-7bf7-478c-9c53-61411c56b337" />

* error state
<img width="1920" height="933" alt="Screenshot 2026-04-01 at 12 03 10 AM" src="https://github.com/user-attachments/assets/b7520471-0ae1-413a-a5c8-c0e77a60b230" />

* empty state
<img width="1920" height="933" alt="Screenshot 2026-03-31 at 10 27 56 PM" src="https://github.com/user-attachments/assets/7fdcc87b-673c-4efe-9108-6df905440655" /> 

* successful data fetch and render
<img width="1920" height="933" alt="Screenshot 2026-03-31 at 11 21 30 PM" src="https://github.com/user-attachments/assets/7dce0d96-d26b-4cfd-a060-115737ca1d7e" />

### Sample Data

* Used locally created test events via SCEvents backend
* Example response from `GET /events`:

```json
[
  {
    "id": "alumni-talk-2026",
    "name": "Alumni Industry Talk",
    "date": "2026-04-15",
    "time": "6:00 PM",
    "location": "Room 123",
    "description": "Hear from SCE alumni working in industry.",
    "admins": [],
    "registration_form": [],
    "max_attendees": 80,
    "created_at": "2026-03-31",
    "status": "published"
  },
  {
    "id": "company-tour-2026",
    "name": "Company Tour",
    "date": "2026-04-20",
    "time": "2:00 PM",
    "location": "San Jose Tech HQ",
    "description": "Tour a real tech company office.",
    "admins": [],
    "registration_form": [],
    "max_attendees": 40,
    "created_at": "2026-03-31",
    "status": "published"
  },
  {
    "id": "resume-workshop-2026",
    "name": "Resume Workshop",
    "date": "2026-04-25",
    "time": "4:30 PM",
    "location": "ENG 285",
    "description": "Get feedback on your resume and prepare for internship season.",
    "admins": [],
    "registration_form": [],
    "max_attendees": 60,
    "created_at": "2026-03-31",
    "status": "published"
  }
]
```