### PR TITLE
Added SCEvents ability to create event

### DIFF
--- a/src/APIFunctions/SCEvents.js
+++ b/src/APIFunctions/SCEvents.js
@@ -83,29 +83,3 @@ export async function createSCEvent(eventBody) {
   }
   return status;
 }
-
-export async function getEventByID(id) {
-  let status = new ApiResponse();
-
-  try {
-    const url = new URL(`/events/${id}`, SCEVENTS_API_URL);
-    const res = await fetch(url.href, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
-
-    if (res.ok) {
-      const result = await res.json();
-      status.responseData = result;
-    } else {
-      status.error = true;
-    }
-  } catch (err) {
-    status.error = true;
-    status.responseData = err;
-  }
-
-  return status;
-}

--- a/src/APIFunctions/SCEvents.js
+++ b/src/APIFunctions/SCEvents.js
@@ -1,35 +1,21 @@
 import { ApiResponse } from './ApiResponses';
 
-export function getSCEventsBaseUrl() {
-  return (
-    (typeof process !== 'undefined' && process.env.REACT_APP_SCEVENTS_URL) ||
-    'http://localhost:8002'
-  );
-}
+const SCEVENTS_BASE =
+  (typeof process !== 'undefined' && process.env.REACT_APP_SCEVENTS_URL) ||
+  'http://localhost:8002';
 
 function eventsUrl(path) {
-  const base = getSCEventsBaseUrl().replace(/\/$/, '');
+  const base = SCEVENTS_BASE.replace(/\/$/, '');
   const p = path.startsWith('/') ? path : `/${path}`;
   return `${base}${p}`;
-}
-
-async function readBodyAsJsonOrText(res) {
-  const text = await res.text();
-  if (!text) {
-    return null;
-  }
-  try {
-    return JSON.parse(text);
-  } catch {
-    return text;
-  }
 }
 
 export async function getAllSCEvents() {
   const status = new ApiResponse();
   try {
     const res = await fetch(eventsUrl('/events/'));
-    status.responseData = await readBodyAsJsonOrText(res);
+    const result = await res.json();
+    status.responseData = result;
     if (!res.ok) {
       status.error = true;
     }
@@ -44,7 +30,8 @@ export async function getEventByID(id) {
   const status = new ApiResponse();
   try {
     const res = await fetch(eventsUrl(`/events/${id}`));
-    status.responseData = await readBodyAsJsonOrText(res);
+    const result = await res.json();
+    status.responseData = result;
     if (!res.ok) {
       status.error = true;
     }
@@ -59,8 +46,7 @@ export async function createSCEvent(eventBody) {
   const status = new ApiResponse();
   status.statusCode = null;
   try {
-    const url = eventsUrl('/events/');
-    const res = await fetch(url, {
+    const res = await fetch(eventsUrl('/events/'), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -68,7 +54,7 @@ export async function createSCEvent(eventBody) {
       body: JSON.stringify(eventBody),
     });
     status.statusCode = res.status;
-    const body = await readBodyAsJsonOrText(res);
+    const body = await res.json();
     if (res.ok) {
       status.responseData = body;
     } else {

--- a/src/APIFunctions/SCEvents.js
+++ b/src/APIFunctions/SCEvents.js
@@ -1,55 +1,85 @@
 import { ApiResponse } from './ApiResponses';
 
-const SCEVENTS_API_URL = 'http://localhost:8080';
+export function getSCEventsBaseUrl() {
+  return (
+    (typeof process !== 'undefined' && process.env.REACT_APP_SCEVENTS_URL) ||
+    'http://localhost:8002'
+  );
+}
+
+function eventsUrl(path) {
+  const base = getSCEventsBaseUrl().replace(/\/$/, '');
+  const p = path.startsWith('/') ? path : `/${path}`;
+  return `${base}${p}`;
+}
+
+async function readBodyAsJsonOrText(res) {
+  const text = await res.text();
+  if (!text) {
+    return null;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
 
 export async function getAllSCEvents() {
-  let status = new ApiResponse();
-
+  const status = new ApiResponse();
   try {
-    const url = new URL('/events/', SCEVENTS_API_URL);
-    const res = await fetch(url.href, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
-
-    if (res.ok) {
-      const result = await res.json();
-      status.responseData = result;
-    } else {
+    const res = await fetch(eventsUrl('/events/'));
+    status.responseData = await readBodyAsJsonOrText(res);
+    if (!res.ok) {
       status.error = true;
     }
   } catch (err) {
-    status.error = true;
     status.responseData = err;
+    status.error = true;
   }
-
   return status;
 }
 
 export async function getEventByID(id) {
-  let status = new ApiResponse();
-
+  const status = new ApiResponse();
   try {
-    const url = new URL(`/events/${id}`, SCEVENTS_API_URL);
-    const res = await fetch(url.href, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
-
-    if (res.ok) {
-      const result = await res.json();
-      status.responseData = result;
-    } else {
+    const res = await fetch(eventsUrl(`/events/${id}`));
+    status.responseData = await readBodyAsJsonOrText(res);
+    if (!res.ok) {
       status.error = true;
     }
   } catch (err) {
-    status.error = true;
     status.responseData = err;
+    status.error = true;
   }
+  return status;
+}
 
+export async function createSCEvent(eventBody) {
+  const status = new ApiResponse();
+  status.statusCode = null;
+  try {
+    const url = eventsUrl('/events/');
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(eventBody),
+    });
+    status.statusCode = res.status;
+    const body = await readBodyAsJsonOrText(res);
+    if (res.ok) {
+      status.responseData = body;
+    } else {
+      status.error = true;
+      status.responseData = body;
+    }
+  } catch (err) {
+    status.error = true;
+    status.responseData =
+      err && typeof err.message === 'string' ? err.message : String(err);
+    status.networkError = true;
+  }
   return status;
 }

--- a/src/APIFunctions/SCEvents.js
+++ b/src/APIFunctions/SCEvents.js
@@ -1,19 +1,11 @@
 import { ApiResponse } from './ApiResponses';
 
-const SCEVENTS_BASE =
-  (typeof process !== 'undefined' && process.env.REACT_APP_SCEVENTS_URL) ||
-  'http://localhost:8002';
-
-function eventsUrl(path) {
-  const base = SCEVENTS_BASE.replace(/\/$/, '');
-  const p = path.startsWith('/') ? path : `/${path}`;
-  return `${base}${p}`;
-}
+const SCEVENTS_API_URL = 'http://localhost:8002';
 
 export async function getAllSCEvents() {
   const status = new ApiResponse();
   try {
-    const res = await fetch(eventsUrl('/events/'));
+    const res = await fetch(`${SCEVENTS_API_URL}/events/`);
     const result = await res.json();
     status.responseData = result;
     if (!res.ok) {
@@ -29,43 +21,37 @@ export async function getAllSCEvents() {
 export async function getEventByID(id) {
   const status = new ApiResponse();
   try {
-    const res = await fetch(eventsUrl(`/events/${id}`));
+    const res = await fetch(`${SCEVENTS_API_URL}/events/${id}`);
     const result = await res.json();
     status.responseData = result;
     if (!res.ok) {
       status.error = true;
     }
   } catch (err) {
-    status.responseData = err;
     status.error = true;
+    status.responseData = err;
   }
   return status;
 }
 
 export async function createSCEvent(eventBody) {
   const status = new ApiResponse();
-  status.statusCode = null;
   try {
-    const res = await fetch(eventsUrl('/events/'), {
+    const res = await fetch(`${SCEVENTS_API_URL}/events/`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(eventBody),
     });
-    status.statusCode = res.status;
     const body = await res.json();
-    if (res.ok) {
-      status.responseData = body;
-    } else {
+    status.responseData = body;
+    if (!res.ok) {
       status.error = true;
-      status.responseData = body;
     }
   } catch (err) {
     status.error = true;
-    status.responseData =
-      err && typeof err.message === 'string' ? err.message : String(err);
-    status.networkError = true;
+    status.responseData = err;
   }
   return status;
 }

--- a/src/APIFunctions/SCEvents.js
+++ b/src/APIFunctions/SCEvents.js
@@ -83,3 +83,29 @@ export async function createSCEvent(eventBody) {
   }
   return status;
 }
+
+export async function getEventByID(id) {
+  let status = new ApiResponse();
+
+  try {
+    const url = new URL(`/events/${id}`, SCEVENTS_API_URL);
+    const res = await fetch(url.href, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (res.ok) {
+      const result = await res.json();
+      status.responseData = result;
+    } else {
+      status.error = true;
+    }
+  } catch (err) {
+    status.error = true;
+    status.responseData = err;
+  }
+
+  return status;
+}

--- a/src/Components/Navbar/AdminNavbar.js
+++ b/src/Components/Navbar/AdminNavbar.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import { useSCE } from '../context/SceContext';
+import config from '../../config/config.json';
+const enums = require('../../Enums.js');
 
 export default function UserNavBar(props) {
   const { user, setAuthenticated } = useSCE();
@@ -40,6 +42,30 @@ export default function UserNavBar(props) {
       ),
     },
   ];
+
+  const sceventsAdminNavLinks = [];
+  if (config.SCEvents?.ENABLED) {
+    sceventsAdminNavLinks.push({
+      title: 'SCEvents',
+      route: '/events',
+      icon: (
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5a2.25 2.25 0 0 0 2.25-2.25m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5a2.25 2.25 0 0 1 2.25 2.25v7.5" />
+        </svg>
+      ),
+    });
+    if (user?.accessLevel >= enums.membershipState.OFFICER) {
+      sceventsAdminNavLinks.push({
+        title: 'Create event',
+        route: '/events/create',
+        icon: (
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+          </svg>
+        ),
+      });
+    }
+  }
 
   const adminLinks = [
     {
@@ -82,6 +108,7 @@ export default function UserNavBar(props) {
         </svg>
       ),
     },
+    ...sceventsAdminNavLinks,
     {
       title: 'Card Reader',
       route: '/card-reader',

--- a/src/Components/Navbar/AdminNavbar.js
+++ b/src/Components/Navbar/AdminNavbar.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useSCE } from '../context/SceContext';
 import config from '../../config/config.json';
-const enums = require('../../Enums.js');
+import { membershipState } from '../../Enums';
 
 export default function UserNavBar(props) {
   const { user, setAuthenticated } = useSCE();
@@ -54,7 +54,7 @@ export default function UserNavBar(props) {
         </svg>
       ),
     });
-    if (user?.accessLevel >= enums.membershipState.OFFICER) {
+    if (user?.accessLevel >= membershipState.OFFICER) {
       sceventsAdminNavLinks.push({
         title: 'Create event',
         route: '/events/create',

--- a/src/Pages/Events/CreateEventFormQuestionBlock.js
+++ b/src/Pages/Events/CreateEventFormQuestionBlock.js
@@ -1,0 +1,120 @@
+/* eslint-disable camelcase -- SCEvents registration question shape uses snake_case */
+import React from 'react';
+
+function newId() {
+  return crypto.randomUUID();
+}
+
+export default function CreateEventFormQuestionBlock({
+  question,
+  index,
+  onUpdateField,
+  onChangeType,
+  onRemove,
+  onUpdateAnswerOption,
+  onAddAnswerOption,
+  onRemoveAnswerOption,
+}) {
+  return (
+    <div className="p-4 mb-3 border border-gray-200 rounded-lg shadow-sm bg-white dark:bg-gray-800 dark:border-gray-700">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
+        <div className="flex flex-wrap flex-1 gap-2 items-center">
+          <span className="flex justify-center items-center w-6 h-6 text-xs font-medium rounded-full bg-primary/15 text-primary">
+            {index + 1}
+          </span>
+          <select
+            value={question.type}
+            onChange={(e) => onChangeType(question.id, e.target.value)}
+            className="text-sm select select-bordered select-sm dark:bg-gray-700"
+          >
+            <option value="textbox">Text input</option>
+            <option value="multiple_choice">Multiple choice</option>
+            <option value="dropdown">Dropdown</option>
+            <option value="checkbox">Checkbox</option>
+          </select>
+          <label className="flex gap-2 items-center text-sm cursor-pointer label">
+            <input
+              type="checkbox"
+              checked={!!question.required}
+              onChange={(e) => onUpdateField(question.id, 'required', e.target.checked)}
+              className="checkbox checkbox-sm"
+            />
+            <span className="label-text">Required</span>
+          </label>
+        </div>
+        <button
+          type="button"
+          className="btn btn-outline btn-sm shrink-0"
+          onClick={() => onRemove(question.id)}
+        >
+          Remove
+        </button>
+      </div>
+
+      <label className="w-full mt-3 form-control">
+        <div className="label">
+          <span className="label-text">Question text</span>
+        </div>
+        <input
+          type="text"
+          className="w-full text-sm input input-bordered sm:text-base"
+          value={question.question}
+          onChange={(e) => onUpdateField(question.id, 'question', e.target.value)}
+          placeholder="Question"
+        />
+      </label>
+
+      {question.type === 'textbox' && (
+        <div className="flex gap-2 items-center mt-2 text-sm">
+          <span className="text-gray-500 dark:text-gray-400">Max characters</span>
+          <input
+            type="number"
+            min="1"
+            className="w-24 input input-bordered input-sm"
+            value={question.answer_details?.max_chars ?? ''}
+            onChange={(e) =>
+              onUpdateField(question.id, 'answer_details', {
+                max_chars: e.target.value ? parseInt(e.target.value, 10) : undefined,
+              })
+            }
+            placeholder="None"
+          />
+        </div>
+      )}
+
+      {(question.type === 'multiple_choice' || question.type === 'dropdown') && (
+        <div className="mt-3 space-y-2">
+          <span className="text-sm text-gray-500 dark:text-gray-400">Answer options</span>
+          {(question.answer_options || []).map((option, optIndex) => (
+            <div key={`${question.id}-opt-${optIndex}`} className="flex gap-2 items-center">
+              <input
+                type="text"
+                className="flex-1 text-sm input input-bordered input-sm"
+                value={option}
+                onChange={(e) => onUpdateAnswerOption(question.id, optIndex, e.target.value)}
+                placeholder={`Option ${optIndex + 1}`}
+              />
+              {(question.answer_options || []).length > 1 && (
+                <button
+                  type="button"
+                  className="btn btn-outline btn-sm btn-square"
+                  onClick={() => onRemoveAnswerOption(question.id, optIndex)}
+                  aria-label="Remove option"
+                >
+                  ×
+                </button>
+              )}
+            </div>
+          ))}
+          <button
+            type="button"
+            className="w-full btn btn-outline btn-sm"
+            onClick={() => onAddAnswerOption(question.id)}
+          >
+            Add option
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/Pages/Events/CreateEventFormQuestionBlock.js
+++ b/src/Pages/Events/CreateEventFormQuestionBlock.js
@@ -1,10 +1,6 @@
 /* eslint-disable camelcase -- SCEvents registration question shape uses snake_case */
 import React from 'react';
 
-function newId() {
-  return crypto.randomUUID();
-}
-
 export default function CreateEventFormQuestionBlock({
   question,
   index,

--- a/src/Pages/Events/CreateEventPage.js
+++ b/src/Pages/Events/CreateEventPage.js
@@ -1,0 +1,383 @@
+/* eslint-disable camelcase -- mirrors SCEvents JSON field names in state and payloads */
+import React, { useMemo, useState } from 'react';
+import { Link, useHistory } from 'react-router-dom';
+import { useSCE } from '../../Components/context/SceContext.js';
+import { createSCEvent, getSCEventsBaseUrl } from '../../APIFunctions/SCEvents.js';
+import CreateEventFormQuestionBlock from './CreateEventFormQuestionBlock.js';
+const enums = require('../../Enums.js');
+
+/** Matches SCEvents `max_attendees` when there is no cap. */
+const UNLIMITED_ATTENDEES = -1;
+
+function newQuestionTemplate() {
+  return {
+    id: crypto.randomUUID(),
+    type: 'textbox',
+    question: '',
+    required: false,
+    answer_details: { max_chars: 200 },
+  };
+}
+
+function defaultQuestions() {
+  return [
+    {
+      id: crypto.randomUUID(),
+      type: 'textbox',
+      question: 'Full Name',
+      required: true,
+      answer_details: { max_chars: 100 },
+    },
+    {
+      id: crypto.randomUUID(),
+      type: 'textbox',
+      question: 'Email Address',
+      required: true,
+      answer_details: { max_chars: 100 },
+    },
+    {
+      id: crypto.randomUUID(),
+      type: 'multiple_choice',
+      question: 'Major',
+      required: false,
+      answer_options: ['Computer Engineering', 'Software Engineering', 'Computer Science', 'Other'],
+    },
+  ];
+}
+
+function toApiRegistrationForm(questions) {
+  return questions.map((q) => {
+    const base = {
+      id: q.id,
+      type: q.type,
+      question: q.question,
+      required: !!q.required,
+    };
+    if (q.type === 'textbox' && q.answer_details?.max_chars) {
+      base.answer_details = { max_chars: q.answer_details.max_chars };
+    }
+    if (
+      (q.type === 'multiple_choice' || q.type === 'dropdown') &&
+      q.answer_options &&
+      q.answer_options.length
+    ) {
+      base.answer_options = q.answer_options;
+    }
+    return base;
+  });
+}
+
+export default function CreateEventPage() {
+  const { user } = useSCE();
+  const history = useHistory();
+  const { membershipState } = enums;
+
+  const [eventId] = useState(() => crypto.randomUUID());
+  const [eventName, setEventName] = useState('');
+  const [date, setDate] = useState(() => {
+    const today = new Date();
+    return today.toISOString().split('T')[0];
+  });
+  const [time, setTime] = useState(() => {
+    const now = new Date();
+    const hours = String(now.getHours()).padStart(2, '0');
+    const minutes = String(now.getMinutes()).padStart(2, '0');
+    return `${hours}:${minutes}`;
+  });
+  const [location, setLocation] = useState('');
+  const [description, setDescription] = useState('');
+  const [maxAttendees, setMaxAttendees] = useState(UNLIMITED_ATTENDEES);
+  const [questions, setQuestions] = useState(defaultQuestions);
+  const [submitError, setSubmitError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const isOfficerOrAdmin = user?.accessLevel >= membershipState.OFFICER;
+
+  const adminId = useMemo(() => (user?._id != null ? String(user._id) : ''), [user]);
+
+  function addQuestion() {
+    setQuestions((prev) => [...prev, newQuestionTemplate()]);
+  }
+
+  function removeQuestion(id) {
+    setQuestions((prev) => prev.filter((q) => q.id !== id));
+  }
+
+  function updateQuestion(id, field, value) {
+    setQuestions((prev) =>
+      prev.map((q) => (q.id === id ? { ...q, [field]: value } : q)),
+    );
+  }
+
+  function updateQuestionType(id, newType) {
+    setQuestions((prev) =>
+      prev.map((q) => {
+        if (q.id !== id) return q;
+        const base = {
+          id: q.id,
+          type: newType,
+          question: q.question,
+          required: q.required,
+        };
+        if (newType === 'textbox') {
+          return { ...base, answer_details: { max_chars: 200 } };
+        }
+        if (newType === 'multiple_choice' || newType === 'dropdown') {
+          return { ...base, answer_options: ['Option 1', 'Option 2'] };
+        }
+        return base;
+      }),
+    );
+  }
+
+  function updateAnswerOption(questionId, optionIndex, value) {
+    setQuestions((prev) =>
+      prev.map((q) => {
+        if (q.id !== questionId) return q;
+        const next = [...(q.answer_options || [])];
+        next[optionIndex] = value;
+        return { ...q, answer_options: next };
+      }),
+    );
+  }
+
+  function addAnswerOption(questionId) {
+    setQuestions((prev) =>
+      prev.map((q) => {
+        if (q.id !== questionId) return q;
+        return {
+          ...q,
+          answer_options: [...(q.answer_options || []), 'New option'],
+        };
+      }),
+    );
+  }
+
+  function removeAnswerOption(questionId, optionIndex) {
+    setQuestions((prev) =>
+      prev.map((q) => {
+        if (q.id !== questionId) return q;
+        return {
+          ...q,
+          answer_options: (q.answer_options || []).filter((_, i) => i !== optionIndex),
+        };
+      }),
+    );
+  }
+
+  async function handleCreateEvent() {
+    setSubmitError('');
+    if (!eventName.trim()) {
+      setSubmitError('Please enter an event name.');
+      return;
+    }
+    if (!adminId) {
+      setSubmitError('Could not resolve your user id.');
+      return;
+    }
+
+    const payload = {
+      id: eventId,
+      name: eventName.trim(),
+      date,
+      time,
+      location: location.trim(),
+      description: description.trim(),
+      admins: [adminId],
+      registration_form: toApiRegistrationForm(questions),
+      max_attendees:
+        maxAttendees === UNLIMITED_ATTENDEES ? UNLIMITED_ATTENDEES : Number(maxAttendees),
+      created_at: new Date().toISOString(),
+      status: 'draft',
+    };
+
+    setSubmitting(true);
+    const result = await createSCEvent(payload);
+    setSubmitting(false);
+
+    if (result.error) {
+      const base = getSCEventsBaseUrl();
+      let msg = '';
+      const data = result.responseData;
+      if (data && typeof data === 'object' && data.error) {
+        msg = String(data.error);
+      } else if (typeof data === 'string' && data.trim()) {
+        msg = data.trim();
+      }
+      if (!msg && result.statusCode) {
+        msg = `HTTP ${result.statusCode}`;
+      }
+      if (result.networkError) {
+        msg =
+          (msg || 'Network error') +
+          `. SCEvents URL: ${base}. Is the API running (e.g. docker compose in SCEvents on port 8083)?`;
+      } else if (!msg) {
+        msg = `SCEvents returned an error. URL: ${base}`;
+      }
+      setSubmitError(msg);
+      return;
+    }
+
+    history.push('/events');
+  }
+
+  if (!isOfficerOrAdmin) {
+    return (
+      <div className="m-10">
+        <h1 className="mb-4 text-3xl font-extrabold text-gray-900 dark:text-white">
+          Create event
+        </h1>
+        <p className="text-gray-600 dark:text-gray-300">
+          Only officers and administrators can create events.
+        </p>
+        <Link to="/events" className="mt-4 btn btn-primary">
+          Back to events
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="m-10 max-w-4xl">
+      <div className="mb-8">
+        <Link to="/events" className="mb-2 text-sm link link-primary">
+          ← Events
+        </Link>
+        <h1 className="text-4xl font-extrabold leading-tight tracking-tight text-gray-900 md:text-5xl dark:text-white">
+          Create event
+        </h1>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">Event id: {eventId}</p>
+      </div>
+
+      <h2 className="mb-3 text-xl font-semibold text-gray-900 dark:text-white">Event details</h2>
+      <div className="p-6 mb-10 space-y-4 border border-gray-200 rounded-lg shadow-sm bg-white dark:bg-gray-800 dark:border-gray-700">
+        <label className="w-full form-control">
+          <div className="label">
+            <span className="label-text">Event name *</span>
+          </div>
+          <input
+            type="text"
+            className="w-full text-sm input input-bordered sm:text-base"
+            value={eventName}
+            onChange={(e) => setEventName(e.target.value)}
+            placeholder="Event name"
+          />
+        </label>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="w-full form-control">
+            <div className="label">
+              <span className="label-text">Date *</span>
+            </div>
+            <input
+              type="date"
+              className="w-full input input-bordered"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+            />
+          </label>
+          <label className="w-full form-control">
+            <div className="label">
+              <span className="label-text">Time *</span>
+            </div>
+            <input
+              type="time"
+              className="w-full input input-bordered"
+              value={time}
+              onChange={(e) => setTime(e.target.value)}
+            />
+          </label>
+        </div>
+
+        <label className="w-full form-control">
+          <div className="label">
+            <span className="label-text">Location</span>
+          </div>
+          <input
+            type="text"
+            className="w-full text-sm input input-bordered sm:text-base"
+            value={location}
+            onChange={(e) => setLocation(e.target.value)}
+            placeholder="Location"
+          />
+        </label>
+
+        <label className="w-full form-control">
+          <div className="label">
+            <span className="label-text">Description</span>
+          </div>
+          <textarea
+            className="w-full min-h-24 textarea textarea-bordered"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Description"
+          />
+        </label>
+
+        <div>
+          <div className="label">
+            <span className="label-text">Max attendees</span>
+          </div>
+          <input
+            type="number"
+            min="1"
+            className="max-w-xs input input-bordered"
+            value={maxAttendees === UNLIMITED_ATTENDEES ? '' : maxAttendees}
+            onChange={(e) =>
+              setMaxAttendees(
+                e.target.value ? parseInt(e.target.value, 10) : UNLIMITED_ATTENDEES,
+              )
+            }
+            placeholder="No limit"
+          />
+        </div>
+      </div>
+
+      <h2 className="mb-3 text-xl font-semibold text-gray-900 dark:text-white">
+        Registration questions
+      </h2>
+      <div className="mb-6 space-y-3">
+        {questions.map((q, index) => (
+          <CreateEventFormQuestionBlock
+            key={q.id}
+            question={q}
+            index={index}
+            onUpdateField={updateQuestion}
+            onChangeType={updateQuestionType}
+            onRemove={removeQuestion}
+            onUpdateAnswerOption={updateAnswerOption}
+            onAddAnswerOption={addAnswerOption}
+            onRemoveAnswerOption={removeAnswerOption}
+          />
+        ))}
+        <button
+          type="button"
+          className="w-full border-2 border-dashed btn btn-outline border-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800"
+          onClick={addQuestion}
+        >
+          + Add question
+        </button>
+      </div>
+
+      {submitError && (
+        <div className="p-3 mb-4 text-sm text-red-700 bg-red-50 rounded-lg dark:bg-red-900/30 dark:text-red-200">
+          {submitError}
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-3 justify-start pt-6 border-t border-gray-200 dark:border-gray-700">
+        <button
+          type="button"
+          className="btn btn-primary"
+          disabled={submitting}
+          onClick={handleCreateEvent}
+        >
+          {submitting ? 'Creating…' : 'Create event'}
+        </button>
+        <Link to="/events" className="btn btn-ghost">
+          Cancel
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/Pages/Events/CreateEventPage.js
+++ b/src/Pages/Events/CreateEventPage.js
@@ -238,15 +238,15 @@ export default function CreateEventPage() {
   }
 
   return (
-    <div className="m-10 max-w-4xl">
-      <div className="mb-8">
-        <Link to="/events" className="mb-2 text-sm link link-primary">
+    <div className="m-10 max-w-4xl px-4 sm:px-6">
+      <div className="mb-8 pt-8 pb-2">
+        <Link to="/events" className="block pb-3 text-sm link link-primary">
           ← Events
         </Link>
-        <h1 className="text-4xl font-extrabold leading-tight tracking-tight text-gray-900 md:text-5xl dark:text-white">
+        <h1 className="pb-3 text-4xl font-extrabold leading-tight tracking-tight text-gray-900 md:text-5xl dark:text-white">
           Create event
         </h1>
-        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">Event id: {eventId}</p>
+        <p className="text-sm text-gray-500 dark:text-gray-400">Event id: {eventId}</p>
       </div>
 
       <h2 className="mb-3 text-xl font-semibold text-gray-900 dark:text-white">Event details</h2>

--- a/src/Pages/Events/CreateEventPage.js
+++ b/src/Pages/Events/CreateEventPage.js
@@ -2,7 +2,7 @@
 import React, { useMemo, useState } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import { useSCE } from '../../Components/context/SceContext.js';
-import { createSCEvent, getSCEventsBaseUrl } from '../../APIFunctions/SCEvents.js';
+import { createSCEvent } from '../../APIFunctions/SCEvents.js';
 import CreateEventFormQuestionBlock from './CreateEventFormQuestionBlock.js';
 import { membershipState } from '../../Enums';
 
@@ -195,7 +195,6 @@ export default function CreateEventPage() {
     setSubmitting(false);
 
     if (result.error) {
-      const base = getSCEventsBaseUrl();
       let msg = '';
       const data = result.responseData;
       if (data && typeof data === 'object' && data.error) {
@@ -209,9 +208,9 @@ export default function CreateEventPage() {
       if (result.networkError) {
         msg =
           (msg || 'Network error') +
-          `. SCEvents URL: ${base}. Is the API running (e.g. SCEvents docker compose on port 8002)?`;
+          '. Is the SCEvents API running (e.g. Docker on port 8002)?';
       } else if (!msg) {
-        msg = `SCEvents returned an error. URL: ${base}`;
+        msg = 'SCEvents returned an error.';
       }
       setSubmitError(msg);
       return;

--- a/src/Pages/Events/CreateEventPage.js
+++ b/src/Pages/Events/CreateEventPage.js
@@ -4,7 +4,7 @@ import { Link, useHistory } from 'react-router-dom';
 import { useSCE } from '../../Components/context/SceContext.js';
 import { createSCEvent, getSCEventsBaseUrl } from '../../APIFunctions/SCEvents.js';
 import CreateEventFormQuestionBlock from './CreateEventFormQuestionBlock.js';
-const enums = require('../../Enums.js');
+import { membershipState } from '../../Enums';
 
 /** Matches SCEvents `max_attendees` when there is no cap. */
 const UNLIMITED_ATTENDEES = -1;
@@ -70,7 +70,6 @@ function toApiRegistrationForm(questions) {
 export default function CreateEventPage() {
   const { user } = useSCE();
   const history = useHistory();
-  const { membershipState } = enums;
 
   const [eventId] = useState(() => crypto.randomUUID());
   const [eventName, setEventName] = useState('');

--- a/src/Pages/Events/CreateEventPage.js
+++ b/src/Pages/Events/CreateEventPage.js
@@ -210,7 +210,7 @@ export default function CreateEventPage() {
       if (result.networkError) {
         msg =
           (msg || 'Network error') +
-          `. SCEvents URL: ${base}. Is the API running (e.g. docker compose in SCEvents on port 8083)?`;
+          `. SCEvents URL: ${base}. Is the API running (e.g. SCEvents docker compose on port 8002)?`;
       } else if (!msg) {
         msg = `SCEvents returned an error. URL: ${base}`;
       }

--- a/src/Pages/Events/Events.js
+++ b/src/Pages/Events/Events.js
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import config from '../../config/config.json';
 import { Link, Redirect } from 'react-router-dom';
 import { getAllSCEvents } from '../../APIFunctions/SCEvents';
+import { useSCE } from '../../Components/context/SceContext';
+import { membershipState } from '../../Enums';
 
 function CalendarIcon() {
   return (
@@ -35,6 +37,21 @@ function PinIcon() {
         d="M12 21s6-5.686 6-11a6 6 0 1 0-12 0c0 5.314 6 11 6 11Z"
       />
       <circle cx="12" cy="10" r="2.5" />
+    </svg>
+  );
+}
+
+function PlusIcon() {
+  return (
+    <svg
+      className="h-5 w-5 flex-shrink-0"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      aria-hidden="true"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 5v14M5 12h14" />
     </svg>
   );
 }
@@ -85,10 +102,12 @@ function EventCard({ event }) {
 }
 
 export default function EventsPage() {
+  const { user } = useSCE();
   const [events, setEvents] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
   const isSCEventsEnabled = config.SCEvents?.ENABLED;
+  const canCreateEvent = user?.accessLevel >= membershipState.OFFICER;
 
   useEffect(() => {
     if (!isSCEventsEnabled) {
@@ -125,9 +144,20 @@ export default function EventsPage() {
       </div>
 
       <div className="relative mx-auto max-w-6xl px-6 py-12">
-        <h1 className="mb-3 text-4xl font-bold text-white md:text-5xl">
-          SCEvents
-        </h1>
+        <div className="mb-3 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <h1 className="text-4xl font-bold text-white md:text-5xl">
+            SCEvents
+          </h1>
+          {canCreateEvent && (
+            <Link
+              to="/events/create"
+              aria-label="Create event"
+              className="inline-flex size-10 shrink-0 items-center justify-center rounded-xl border border-white/20 bg-white/10 text-white shadow-sm backdrop-blur transition hover:border-white/30 hover:bg-white/[0.15]"
+            >
+              <PlusIcon />
+            </Link>
+          )}
+        </div>
 
         <div className="mb-6 h-[2px] w-28 rounded-full bg-gradient-to-r from-sky-400 via-blue-400 to-indigo-400" />
 

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -20,6 +20,7 @@ import CardReader from './Pages/CardReader/CardReader.js';
 import AuditLogsPage from './Pages/AuditLog/AuditLog.js';
 import PermissionRequestPage from './Pages/PermissionRequest/PermissionRequest.js';
 import EventsPage from './Pages/Events/Events.js';
+import CreateEventPage from './Pages/Events/CreateEventPage.js';
 import EventRegistration from './Pages/Events/EventsRegistation.js';
 
 // Declare an enum for permission check
@@ -164,6 +165,14 @@ export const officerOrAdminRoutes = [
     Component: AuditLogsPage,
     path: '/audit-logs',
     pageName: 'Audit Log',
+    allowedIf: allowedIf.OFFICER_OR_ADMIN,
+    redirect: '/',
+    inAdminNavbar: true
+  },
+  {
+    Component: CreateEventPage,
+    path: '/events/create',
+    pageName: 'Create Event',
     allowedIf: allowedIf.OFFICER_OR_ADMIN,
     redirect: '/',
     inAdminNavbar: true


### PR DESCRIPTION
PR for issue [2068](https://github.com/SCE-Development/Clark/issues/2068)

Added Clark UI and wiring for SCEvents: officers and admins can open the events page and use a create event flow that talks to the SCEvents HTTP API. Submitted events are stored by SCEvents in its own MongoDB (scevents / events), not Clark’s main API database.

- API client (src/APIFunctions/SCEvents.js): getSCEvents, createSCEvent, configurable base URL via - REACT_APP_SCEVENTS_URL (with a local dev fallback).
- Pages: Events.js (listing + Create CTA for officers/admins), CreateEventPage.js + CreateEventFormQuestionBlock.js (form aligned with SCEvents event/registration payload shape).
- Routing: Registered /events and /events/create in Routes.js with OFFICER_OR_ADMIN access for the create route.
- Nav: Admin sidebar links for SCEvents and Create event when config.SCEvents.ENABLED is true (AdminNavbar.js).
- Auth: Create-event access is officer or admin (consistent with other officer/admin tools), not admin-only.

Screenshots of what this would look like

<img width="1822" height="1184" alt="Screenshot 2026-04-01 at 4 06 18 PM" src="https://github.com/user-attachments/assets/35aa6f9a-51e7-4709-a652-a014f265897c" />
<img width="1822" height="1184" alt="Screenshot 2026-04-01 at 4 06 21 PM" src="https://github.com/user-attachments/assets/a7fb2cd0-cf89-4863-affd-9c374ca63f5c" />
<img width="1822" height="1184" alt="Screenshot 2026-04-01 at 4 06 25 PM" src="https://github.com/user-attachments/assets/4a6d1d4a-6f75-4399-845b-66559b32ce96" />
<img width="1710" height="985" alt="Screenshot 2026-04-03 at 12 02 25 AM" src="https://github.com/user-attachments/assets/1d2f58b2-2c85-4a65-8696-6ddd9d68ebd2" />
