### PR TITLE
Add Event Edit Page

### DIFF
--- a/src/APIFunctions/SCEvents.js
+++ b/src/APIFunctions/SCEvents.js
@@ -1,8 +1,6 @@
 import { ApiResponse } from './ApiResponses';
 
 const SCEVENTS_API_URL = 'http://localhost:8002';
-
-// ======== ORIGINAL BACKEND API REQUESTS ========
 export async function getAllSCEvents() {
   const status = new ApiResponse();
   try {
@@ -78,72 +76,3 @@ export async function updateSCEvent(id, userId, eventUpdates) {
   }
   return status;
 }
-// =================================================
-
-
-// ======== MOCKED LOCAL STORAGE VERSIONS ========
-// const getMockEvents = () => {
-//   const data = localStorage.getItem('mockSCEvents');
-//   // Initialize with empty array if null
-//   return data ? JSON.parse(data) : [];
-// };
-
-// const setMockEvents = (events) => {
-//   localStorage.setItem('mockSCEvents', JSON.stringify(events));
-// };
-
-// export async function getAllSCEvents() {
-//   const status = new ApiResponse();
-//   // Simulated network delay
-//   await new Promise(resolve => setTimeout(resolve, 300));
-//   status.responseData = getMockEvents();
-//   status.error = false;
-//   return status;
-// }
-
-// export async function getEventByID(id) {
-//   const status = new ApiResponse();
-//   await new Promise(resolve => setTimeout(resolve, 300));
-//   const events = getMockEvents();
-//   const event = events.find(e => e.id === id || e._id === id);
-//   if (event) {
-//     status.responseData = event;
-//     status.error = false;
-//   } else {
-//     status.error = true;
-//     status.responseData = 'Event not found in mock local storage.';
-//   }
-//   return status;
-// }
-
-// export async function createSCEvent(eventBody) {
-//   const status = new ApiResponse();
-//   await new Promise(resolve => setTimeout(resolve, 300));
-//   const events = getMockEvents();
-//   // Simulate backend appending the event
-//   events.push(eventBody);
-//   setMockEvents(events);
-
-//   status.responseData = eventBody;
-//   status.error = false;
-//   return status;
-// }
-
-// export async function updateSCEvent(id, userId, eventUpdates) {
-//   const status = new ApiResponse();
-//   await new Promise(resolve => setTimeout(resolve, 300));
-//   const events = getMockEvents();
-//   const index = events.findIndex(e => e.id === id || e._id === id);
-//   if (index !== -1) {
-//     // Note: A real backend would verify `userId` here, but for simple mocked testing:
-//     events[index] = { ...events[index], ...eventUpdates };
-//     setMockEvents(events);
-
-//     status.responseData = { message: 'Updated successfully in mock local storage' };
-//     status.error = false;
-//   } else {
-//     status.error = true;
-//     status.responseData = 'Event not found in mock local storage.';
-//   }
-//   return status;
-// }

--- a/src/APIFunctions/SCEvents.js
+++ b/src/APIFunctions/SCEvents.js
@@ -2,6 +2,7 @@ import { ApiResponse } from './ApiResponses';
 
 const SCEVENTS_API_URL = 'http://localhost:8002';
 
+// ======== ORIGINAL BACKEND API REQUESTS ========
 export async function getAllSCEvents() {
   const status = new ApiResponse();
   try {
@@ -55,3 +56,94 @@ export async function createSCEvent(eventBody) {
   }
   return status;
 }
+
+export async function updateSCEvent(id, userId, eventUpdates) {
+  const status = new ApiResponse();
+  try {
+    const res = await fetch(`${SCEVENTS_API_URL}/events/${id}?user_id=${userId}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(eventUpdates),
+    });
+    const body = await res.json();
+    status.responseData = body;
+    if (!res.ok) {
+      status.error = true;
+    }
+  } catch (err) {
+    status.error = true;
+    status.responseData = err;
+  }
+  return status;
+}
+// =================================================
+
+
+// ======== MOCKED LOCAL STORAGE VERSIONS ========
+// const getMockEvents = () => {
+//   const data = localStorage.getItem('mockSCEvents');
+//   // Initialize with empty array if null
+//   return data ? JSON.parse(data) : [];
+// };
+
+// const setMockEvents = (events) => {
+//   localStorage.setItem('mockSCEvents', JSON.stringify(events));
+// };
+
+// export async function getAllSCEvents() {
+//   const status = new ApiResponse();
+//   // Simulated network delay
+//   await new Promise(resolve => setTimeout(resolve, 300));
+//   status.responseData = getMockEvents();
+//   status.error = false;
+//   return status;
+// }
+
+// export async function getEventByID(id) {
+//   const status = new ApiResponse();
+//   await new Promise(resolve => setTimeout(resolve, 300));
+//   const events = getMockEvents();
+//   const event = events.find(e => e.id === id || e._id === id);
+//   if (event) {
+//     status.responseData = event;
+//     status.error = false;
+//   } else {
+//     status.error = true;
+//     status.responseData = 'Event not found in mock local storage.';
+//   }
+//   return status;
+// }
+
+// export async function createSCEvent(eventBody) {
+//   const status = new ApiResponse();
+//   await new Promise(resolve => setTimeout(resolve, 300));
+//   const events = getMockEvents();
+//   // Simulate backend appending the event
+//   events.push(eventBody);
+//   setMockEvents(events);
+
+//   status.responseData = eventBody;
+//   status.error = false;
+//   return status;
+// }
+
+// export async function updateSCEvent(id, userId, eventUpdates) {
+//   const status = new ApiResponse();
+//   await new Promise(resolve => setTimeout(resolve, 300));
+//   const events = getMockEvents();
+//   const index = events.findIndex(e => e.id === id || e._id === id);
+//   if (index !== -1) {
+//     // Note: A real backend would verify `userId` here, but for simple mocked testing:
+//     events[index] = { ...events[index], ...eventUpdates };
+//     setMockEvents(events);
+
+//     status.responseData = { message: 'Updated successfully in mock local storage' };
+//     status.error = false;
+//   } else {
+//     status.error = true;
+//     status.responseData = 'Event not found in mock local storage.';
+//   }
+//   return status;
+// }

--- a/src/Components/context/SceContext.js
+++ b/src/Components/context/SceContext.js
@@ -2,26 +2,11 @@ import React, { createContext, useContext } from 'react';
 
 export const SceContext = createContext({
   user: {},
-  setUser: () => { },
+  setUser: () => {},
   authenticated: false,
-  setAuthenticated: () => { },
+  setAuthenticated: () => {},
 });
 
-// ======== ORIGINAL useSCE LOGIC ========
 export function useSCE() {
   return useContext(SceContext);
 }
-// ==========================================
-
-// ======== MOCKED VERSION FOR TESTING ========
-// export function useSCE() {
-//   const context = useContext(SceContext);
-//   return {
-//     ...context,
-//     user: {
-//       ...context.user,
-//       accessLevel: 3, // Temporarily forced to ADMIN for testing
-//       _id: context.user?._id || 'mocked-id-for-testing'
-//     }
-//   };
-// }

--- a/src/Components/context/SceContext.js
+++ b/src/Components/context/SceContext.js
@@ -2,11 +2,26 @@ import React, { createContext, useContext } from 'react';
 
 export const SceContext = createContext({
   user: {},
-  setUser: () => {},
+  setUser: () => { },
   authenticated: false,
-  setAuthenticated: () => {},
+  setAuthenticated: () => { },
 });
 
+// ======== ORIGINAL useSCE LOGIC ========
 export function useSCE() {
   return useContext(SceContext);
 }
+// ==========================================
+
+// ======== MOCKED VERSION FOR TESTING ========
+// export function useSCE() {
+//   const context = useContext(SceContext);
+//   return {
+//     ...context,
+//     user: {
+//       ...context.user,
+//       accessLevel: 3, // Temporarily forced to ADMIN for testing
+//       _id: context.user?._id || 'mocked-id-for-testing'
+//     }
+//   };
+// }

--- a/src/Pages/Events/CreateEventPage.js
+++ b/src/Pages/Events/CreateEventPage.js
@@ -1,10 +1,11 @@
 /* eslint-disable camelcase -- mirrors SCEvents JSON field names in state and payloads */
 import React, { useMemo, useState } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { Link, useHistory, Redirect } from 'react-router-dom';
 import { useSCE } from '../../Components/context/SceContext.js';
 import { createSCEvent } from '../../APIFunctions/SCEvents.js';
 import CreateEventFormQuestionBlock from './CreateEventFormQuestionBlock.js';
 import { membershipState } from '../../Enums';
+import config from '../../config/config.json';
 
 /** Matches SCEvents `max_attendees` when there is no cap. */
 const UNLIMITED_ATTENDEES = -1;
@@ -70,6 +71,7 @@ function toApiRegistrationForm(questions) {
 export default function CreateEventPage() {
   const { user } = useSCE();
   const history = useHistory();
+  const isSCEventsEnabled = config.SCEvents?.ENABLED;
 
   const [eventId] = useState(() => crypto.randomUUID());
   const [eventName, setEventName] = useState('');
@@ -217,6 +219,10 @@ export default function CreateEventPage() {
     }
 
     history.push('/events');
+  }
+
+  if (!isSCEventsEnabled) {
+    return <Redirect to="/notfound" />;
   }
 
   if (!isOfficerOrAdmin) {

--- a/src/Pages/Events/EditEventPage.js
+++ b/src/Pages/Events/EditEventPage.js
@@ -1,8 +1,8 @@
 /* eslint-disable camelcase -- mirrors SCEvents JSON field names in state and payloads */
-import React, { useMemo, useState } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import React, { useMemo, useState, useEffect } from 'react';
+import { Link, useHistory, useParams } from 'react-router-dom';
 import { useSCE } from '../../Components/context/SceContext.js';
-import { createSCEvent } from '../../APIFunctions/SCEvents.js';
+import { getEventByID, updateSCEvent } from '../../APIFunctions/SCEvents.js';
 import CreateEventFormQuestionBlock from './CreateEventFormQuestionBlock.js';
 import { membershipState } from '../../Enums';
 
@@ -17,32 +17,6 @@ function newQuestionTemplate() {
     required: false,
     answer_details: { max_chars: 200 },
   };
-}
-
-function defaultQuestions() {
-  return [
-    {
-      id: crypto.randomUUID(),
-      type: 'textbox',
-      question: 'Full Name',
-      required: true,
-      answer_details: { max_chars: 100 },
-    },
-    {
-      id: crypto.randomUUID(),
-      type: 'textbox',
-      question: 'Email Address',
-      required: true,
-      answer_details: { max_chars: 100 },
-    },
-    {
-      id: crypto.randomUUID(),
-      type: 'multiple_choice',
-      question: 'Major',
-      required: false,
-      answer_options: ['Computer Engineering', 'Software Engineering', 'Computer Science', 'Other'],
-    },
-  ];
 }
 
 function toApiRegistrationForm(questions) {
@@ -67,51 +41,71 @@ function toApiRegistrationForm(questions) {
   });
 }
 
-export default function CreateEventPage() {
+export default function EditEventPage() {
+  const { id } = useParams();
   const { user } = useSCE();
   const history = useHistory();
 
-  const [eventId] = useState(() => crypto.randomUUID());
+  const [isLoading, setIsLoading] = useState(true);
+  const [fetchError, setFetchError] = useState('');
+
   const [eventName, setEventName] = useState('');
-  const [date, setDate] = useState(() => {
-    const today = new Date();
-    return today.toISOString().split('T')[0];
-  });
-  const [time, setTime] = useState(() => {
-    const now = new Date();
-    const hours = String(now.getHours()).padStart(2, '0');
-    const minutes = String(now.getMinutes()).padStart(2, '0');
-    return `${hours}:${minutes}`;
-  });
+  const [date, setDate] = useState('');
+  const [time, setTime] = useState('');
   const [location, setLocation] = useState('');
   const [description, setDescription] = useState('');
   const [maxAttendees, setMaxAttendees] = useState(UNLIMITED_ATTENDEES);
-  const [questions, setQuestions] = useState(defaultQuestions);
+  const [questions, setQuestions] = useState([]);
+  const [eventAdmins, setEventAdmins] = useState([]);
+
   const [submitError, setSubmitError] = useState('');
   const [submitting, setSubmitting] = useState(false);
 
   const isOfficerOrAdmin = user?.accessLevel >= membershipState.OFFICER;
+  const userId = useMemo(() => (user?._id != null ? String(user._id) : ''), [user]);
 
-  const adminId = useMemo(() => (user?._id != null ? String(user._id) : ''), [user]);
+  useEffect(() => {
+    async function loadEvent() {
+      setIsLoading(true);
+      const result = await getEventByID(id);
+      setIsLoading(false);
+
+      if (result.error) {
+        setFetchError('Failed to load event details.');
+        return;
+      }
+
+      const evt = result.responseData;
+      setEventName(evt.name || '');
+      setDate(evt.date || '');
+      setTime(evt.time || '');
+      setLocation(evt.location || '');
+      setDescription(evt.description || '');
+      setMaxAttendees(evt.max_attendees || UNLIMITED_ATTENDEES);
+      setQuestions(evt.registration_form || []);
+      setEventAdmins(evt.admins || []);
+    }
+    loadEvent();
+  }, [id]);
 
   function addQuestion() {
     setQuestions((prev) => [...prev, newQuestionTemplate()]);
   }
 
-  function removeQuestion(id) {
-    setQuestions((prev) => prev.filter((q) => q.id !== id));
+  function removeQuestion(qId) {
+    setQuestions((prev) => prev.filter((q) => q.id !== qId));
   }
 
-  function updateQuestion(id, field, value) {
+  function updateQuestion(qId, field, value) {
     setQuestions((prev) =>
-      prev.map((q) => (q.id === id ? { ...q, [field]: value } : q)),
+      prev.map((q) => (q.id === qId ? { ...q, [field]: value } : q)),
     );
   }
 
-  function updateQuestionType(id, newType) {
+  function updateQuestionType(qId, newType) {
     setQuestions((prev) =>
       prev.map((q) => {
-        if (q.id !== id) return q;
+        if (q.id !== qId) return q;
         const base = {
           id: q.id,
           type: newType,
@@ -164,34 +158,26 @@ export default function CreateEventPage() {
     );
   }
 
-  async function handleCreateEvent() {
+  async function handleUpdateEvent() {
     setSubmitError('');
     if (!eventName.trim()) {
       setSubmitError('Please enter an event name.');
       return;
     }
-    if (!adminId) {
-      setSubmitError('Could not resolve your user id.');
-      return;
-    }
 
     const payload = {
-      id: eventId,
       name: eventName.trim(),
       date,
       time,
       location: location.trim(),
       description: description.trim(),
-      admins: [adminId],
       registration_form: toApiRegistrationForm(questions),
       max_attendees:
         maxAttendees === UNLIMITED_ATTENDEES ? UNLIMITED_ATTENDEES : Number(maxAttendees),
-      created_at: new Date().toISOString(),
-      status: 'draft',
     };
 
     setSubmitting(true);
-    const result = await createSCEvent(payload);
+    const result = await updateSCEvent(id, userId, payload);
     setSubmitting(false);
 
     if (result.error) {
@@ -223,10 +209,43 @@ export default function CreateEventPage() {
     return (
       <div className="m-10">
         <h1 className="mb-4 text-3xl font-extrabold text-gray-900 dark:text-white">
-          Create event
+          Edit event
         </h1>
         <p className="text-gray-600 dark:text-gray-300">
-          Only officers and administrators can create events.
+          Only officers and administrators can edit events.
+        </p>
+        <Link to="/events" className="mt-4 btn btn-primary">
+          Back to events
+        </Link>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return <div className="p-10 text-center text-lg">Loading event details...</div>;
+  }
+
+  if (fetchError) {
+    return (
+      <div className="p-10 text-center text-lg text-red-500">
+        {fetchError}
+        <br />
+        <Link to="/events" className="mt-4 btn btn-primary">
+          Back to events
+        </Link>
+      </div>
+    );
+  }
+
+  const isEventAdmin = eventAdmins.includes(userId);
+  if (!isEventAdmin) {
+    return (
+      <div className="m-10">
+        <h1 className="mb-4 text-3xl font-extrabold text-gray-900 dark:text-white">
+          Edit event
+        </h1>
+        <p className="text-gray-600 dark:text-gray-300">
+          You are not an admin of this event.
         </p>
         <Link to="/events" className="mt-4 btn btn-primary">
           Back to events
@@ -236,15 +255,15 @@ export default function CreateEventPage() {
   }
 
   return (
-    <div className="m-10 max-w-4xl px-4 sm:px-6">
+    <div className="mx-auto my-10 max-w-4xl px-4 sm:px-6">
       <div className="mb-8 pt-8 pb-2">
         <Link to="/events" className="btn btn-ghost normal-case text-base pl-0 mb-4 font-medium text-gray-400 hover:text-white hover:bg-transparent">
           ← Back to Events
         </Link>
         <h1 className="pb-3 text-4xl font-extrabold leading-tight tracking-tight text-gray-900 md:text-5xl dark:text-white">
-          Create event
+          Edit event
         </h1>
-        <p className="text-sm text-gray-500 dark:text-gray-400">Event id: {eventId}</p>
+        <p className="text-sm text-gray-500 dark:text-gray-400">Event id: {id}</p>
       </div>
 
       <h2 className="mb-3 text-xl font-semibold text-gray-900 dark:text-white">Event details</h2>
@@ -368,9 +387,9 @@ export default function CreateEventPage() {
           type="button"
           className="btn btn-primary"
           disabled={submitting}
-          onClick={handleCreateEvent}
+          onClick={handleUpdateEvent}
         >
-          {submitting ? 'Creating…' : 'Create event'}
+          {submitting ? 'Updating…' : 'Save changes'}
         </button>
         <Link to="/events" className="btn btn-ghost">
           Cancel

--- a/src/Pages/Events/EditEventPage.js
+++ b/src/Pages/Events/EditEventPage.js
@@ -1,10 +1,11 @@
 /* eslint-disable camelcase -- mirrors SCEvents JSON field names in state and payloads */
 import React, { useMemo, useState, useEffect } from 'react';
-import { Link, useHistory, useParams } from 'react-router-dom';
+import { Link, useHistory, useParams, Redirect } from 'react-router-dom';
 import { useSCE } from '../../Components/context/SceContext.js';
 import { getEventByID, updateSCEvent } from '../../APIFunctions/SCEvents.js';
 import CreateEventFormQuestionBlock from './CreateEventFormQuestionBlock.js';
 import { membershipState } from '../../Enums';
+import config from '../../config/config.json';
 
 /** Matches SCEvents `max_attendees` when there is no cap. */
 const UNLIMITED_ATTENDEES = -1;
@@ -45,6 +46,7 @@ export default function EditEventPage() {
   const { id } = useParams();
   const { user } = useSCE();
   const history = useHistory();
+  const isSCEventsEnabled = config.SCEvents?.ENABLED;
 
   const [isLoading, setIsLoading] = useState(true);
   const [fetchError, setFetchError] = useState('');
@@ -85,8 +87,13 @@ export default function EditEventPage() {
       setQuestions(evt.registration_form || []);
       setEventAdmins(evt.admins || []);
     }
+
+    if (!isSCEventsEnabled) {
+      return;
+    }
+
     loadEvent();
-  }, [id]);
+  }, [id, isSCEventsEnabled]);
 
   function addQuestion() {
     setQuestions((prev) => [...prev, newQuestionTemplate()]);
@@ -203,6 +210,10 @@ export default function EditEventPage() {
     }
 
     history.push('/events');
+  }
+
+  if (!isSCEventsEnabled) {
+    return <Redirect to="/notfound" />;
   }
 
   if (!isOfficerOrAdmin) {

--- a/src/Pages/Events/Events.js
+++ b/src/Pages/Events/Events.js
@@ -56,12 +56,43 @@ function PlusIcon() {
   );
 }
 
-function EventCard({ event }) {
+function EditIcon() {
   return (
-    <div className="group flex flex-col rounded-2xl border border-white/10 bg-white/5 p-6 shadow-md backdrop-blur-sm transition duration-300 hover:-translate-y-1 hover:border-white/20 hover:bg-white/[0.07]">
-      <h2 className="mb-4 text-2xl font-bold text-white">
-        {event.name || 'Untitled Event'}
-      </h2>
+    <svg
+      className="h-5 w-5 flex-shrink-0"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+      <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+    </svg>
+  );
+}
+
+function EventCard({ event, user }) {
+  const isAdmin = event.admins && user?._id && event.admins.includes(String(user._id));
+
+  return (
+    <div className="group relative flex flex-col rounded-2xl border border-white/10 bg-white/5 p-6 shadow-md backdrop-blur-sm transition duration-300 hover:-translate-y-1 hover:border-white/20 hover:bg-white/[0.07]">
+      <div className="flex items-start justify-between">
+        <h2 className="mb-4 pr-4 text-2xl font-bold text-white">
+          {event.name || 'Untitled Event'}
+        </h2>
+        {isAdmin && (
+          <Link
+            to={`/events/${event.id}/edit`}
+            className="rounded-lg p-2 text-gray-400 hover:bg-white/10 hover:text-emerald-400 transition-colors duration-200"
+            title="Edit Event"
+          >
+            <EditIcon />
+          </Link>
+        )}
+      </div>
 
       <div className="mb-5 space-y-2 text-sm text-gray-300">
         {(event.date || event.time) && (
@@ -188,7 +219,7 @@ export default function EventsPage() {
         {!isLoading && !hasError && events.length > 0 && (
           <div className="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
             {events.map((event) => (
-              <EventCard key={event.id} event={event} />
+              <EventCard key={event.id} event={event} user={user} />
             ))}
           </div>
         )}

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -22,6 +22,7 @@ import PermissionRequestPage from './Pages/PermissionRequest/PermissionRequest.j
 import EventsPage from './Pages/Events/Events.js';
 import CreateEventPage from './Pages/Events/CreateEventPage.js';
 import EventRegistration from './Pages/Events/EventsRegistation.js';
+import EditEventPage from './Pages/Events/EditEventPage.js';
 
 // Declare an enum for permission check
 export const allowedIf = {
@@ -176,6 +177,14 @@ export const officerOrAdminRoutes = [
     allowedIf: allowedIf.OFFICER_OR_ADMIN,
     redirect: '/',
     inAdminNavbar: true
+  },
+  {
+    Component: EditEventPage,
+    path: '/events/:id/edit',
+    pageName: 'Edit Event',
+    allowedIf: allowedIf.OFFICER_OR_ADMIN,
+    redirect: '/',
+    inAdminNavbar: false
   },
   ...memberRoutes,
 ];


### PR DESCRIPTION
I changed these:
- add Event Edit page ( just the same format with create page) 
- add the little button edit on the top right corner
- Temporarily grant Admin permission for create and update event
- Authorization will add later
- currently enable the SCE events 
Before:
<img width="2559" height="1404" alt="image" src="https://github.com/user-attachments/assets/2422f411-324a-4667-b53e-c1ce8fa34cb6" />
We can edit registeration form too:
<img width="2079" height="1338" alt="image" src="https://github.com/user-attachments/assets/79de549c-4880-4c27-b770-a56c58938b0e" />
<img width="2544" height="1386" alt="image" src="https://github.com/user-attachments/assets/290fe3a9-ccab-4188-88d6-e712fcc5f542" />
after update event:
<img width="2488" height="1402" alt="image" src="https://github.com/user-attachments/assets/9482c87b-c836-45de-85a4-efba6904ba80" />
