### PR TITLE
Add token to requests sent to SCEvents' protected routes

### DIFF
--- a/src/APIFunctions/SCEvents.js
+++ b/src/APIFunctions/SCEvents.js
@@ -33,13 +33,14 @@ export async function getEventByID(id) {
   return status;
 }
 
-export async function createSCEvent(eventBody) {
+export async function createSCEvent(token, eventBody) {
   const status = new ApiResponse();
   try {
     const res = await fetch(`${SCEVENTS_API_URL}/events/`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify(eventBody),
     });
@@ -55,13 +56,14 @@ export async function createSCEvent(eventBody) {
   return status;
 }
 
-export async function updateSCEvent(id, userId, eventUpdates) {
+export async function updateSCEvent(id, token, eventUpdates) {
   const status = new ApiResponse();
   try {
-    const res = await fetch(`${SCEVENTS_API_URL}/events/${id}?user_id=${userId}`, {
+    const res = await fetch(`${SCEVENTS_API_URL}/events/${id}`, {
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify(eventUpdates),
     });

--- a/src/Pages/Events/CreateEventPage.js
+++ b/src/Pages/Events/CreateEventPage.js
@@ -193,7 +193,8 @@ export default function CreateEventPage() {
     };
 
     setSubmitting(true);
-    const result = await createSCEvent(payload);
+    const token = window.localStorage.getItem('jwtToken');
+    const result = await createSCEvent(token, payload);
     setSubmitting(false);
 
     if (result.error) {

--- a/src/Pages/Events/EditEventPage.js
+++ b/src/Pages/Events/EditEventPage.js
@@ -184,7 +184,8 @@ export default function EditEventPage() {
     };
 
     setSubmitting(true);
-    const result = await updateSCEvent(id, userId, payload);
+    const token = window.localStorage.getItem('jwtToken');
+    const result = await updateSCEvent(id, token, payload);
     setSubmitting(false);
 
     if (result.error) {


### PR DESCRIPTION
resolves #2086

**CHANGES**
- SCEvents endpoints need to be protected --> we need a way for SCEvents to know that if it gets a request, it's actually from Clark
- to do this... we'll pass the JWT token to protected requests... and determine if the user is valid (ex. is an admin, is a member)

**TESTING**
- created event
<img width="1302" height="837" alt="image" src="https://github.com/user-attachments/assets/090a7c6a-d22f-4092-9ddd-f4649362e6d7" />
<img width="1237" height="477" alt="image" src="https://github.com/user-attachments/assets/62278f60-6b37-4d7e-9f94-f9bfad28ff80" />

- backend logs showed it worked
```
[GIN-debug] Listening and serving HTTP on :8002
2026/04/18 03:50:59 API Response: {"firstName":"s","lastName":"s","email":"s@s.com","accessLevel":3,"pagesPrinted":0,"_id":"69e2fcf01b021f53d4560965","iat":1776483725,"exp":1776490925}
[GIN] 2026/04/18 - 03:50:59 | 201 |   29.4ms |      172.19.0.1 | POST     "/events/"
[GIN] 2026/04/18 - 03:50:59 | 200 |   6.08ms |      172.19.0.1 | GET      "/events/"
```

note: this is to be merged alongside https://github.com/SCE-Development/SCEvents/pull/69