### PR TITLE
Add SCEvents link to authenticated user navbar

### DIFF
--- a/src/Components/Navbar/UserNavbar.js
+++ b/src/Components/Navbar/UserNavbar.js
@@ -22,6 +22,7 @@ export default function UserNavbar(props) {
     { title: 'Printing', route: '/2DPrinting' },
     { title: 'Chat', route: '/messaging' },
     { title: 'LED Sign', route: '/led-sign' },
+    ...(config.SCEvents?.ENABLED ? [{ title: 'SCEvents', route: '/events' }] : []),
   ];
 
   const authentication = [


### PR DESCRIPTION
## Changes
Added SCEvents route to `authedRoutes` in `UserNavbar.js`

## Why
Previously, SCEvents was only visible to unauthenticated users due to route separation logic. This change ensures all users can access the Events page.

## Screenshots
- feature flag OFF
<img width="1920" height="930" alt="Screenshot 2026-04-17 at 10 11 30 PM" src="https://github.com/user-attachments/assets/dea2bf29-c8bc-4b37-b9d6-02fcb81db300" />
<img width="1920" height="930" alt="Screenshot 2026-04-17 at 10 11 05 PM" src="https://github.com/user-attachments/assets/36bff8b7-fb9a-4567-8f39-eb437f1ee5a5" />

- feature flag ON
   - Before: SCEvents missing for authenticated users
<img width="1920" height="930" alt="Screenshot 2026-04-17 at 10 03 18 PM" src="https://github.com/user-attachments/assets/330e25ea-eb84-4026-bff5-d9bccbfa952a" />

   - After: SCEvents visible for member/officer/admin
<img width="1920" height="930" alt="Screenshot 2026-04-17 at 10 04 22 PM" src="https://github.com/user-attachments/assets/864a145f-db12-4687-b091-77f8a82fe2a6" />
<img width="1920" height="930" alt="Screenshot 2026-04-17 at 10 04 39 PM" src="https://github.com/user-attachments/assets/464fe672-3271-43e5-84df-7b2808cfdf34" />
<img width="1920" height="930" alt="Screenshot 2026-04-17 at 10 04 51 PM" src="https://github.com/user-attachments/assets/fb5cf197-42dd-4133-950a-6e18c58c5474" />