### PR TITLE
Add SCEvents visibility and edit-access handling

### DIFF
--- a/src/Pages/Events/CreateEventPage.js
+++ b/src/Pages/Events/CreateEventPage.js
@@ -87,6 +87,9 @@ export default function CreateEventPage() {
   });
   const [location, setLocation] = useState('');
   const [description, setDescription] = useState('');
+  const [status, setStatus] = useState('draft');
+  const [visibility, setVisibility] = useState('public');
+  const [minimumVisibleRole, setMinimumVisibleRole] = useState('');
   const [maxAttendees, setMaxAttendees] = useState(UNLIMITED_ATTENDEES);
   const [questions, setQuestions] = useState(defaultQuestions);
   const [submitError, setSubmitError] = useState('');
@@ -176,6 +179,10 @@ export default function CreateEventPage() {
       setSubmitError('Could not resolve your user id.');
       return;
     }
+    if (visibility === 'private' && !minimumVisibleRole) {
+      setSubmitError('Please select a minimum visible role for private events.');
+      return;
+    }
 
     const payload = {
       id: eventId,
@@ -184,12 +191,14 @@ export default function CreateEventPage() {
       time,
       location: location.trim(),
       description: description.trim(),
-      admins: [adminId],
+      admins: [adminId],  // The event creator becomes the initial event admin in SCEvents
       registration_form: toApiRegistrationForm(questions),
       max_attendees:
         maxAttendees === UNLIMITED_ATTENDEES ? UNLIMITED_ATTENDEES : Number(maxAttendees),
       created_at: new Date().toISOString(),
-      status: 'draft',
+      status,
+      visibility,
+      minimum_visible_role: visibility === 'private' ? minimumVisibleRole : '',
     };
 
     setSubmitting(true);
@@ -336,6 +345,61 @@ export default function CreateEventPage() {
             placeholder="No limit"
           />
         </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="w-full form-control">
+            <div className="label">
+              <span className="label-text">Publish status</span>
+            </div>
+            <select
+              className="w-full select select-bordered"
+              value={status}
+              onChange={(e) => setStatus(e.target.value)}
+            >
+              <option value="draft">Draft</option>
+              <option value="published">Published</option>
+              <option value="closed">Closed</option>
+            </select>
+          </label>
+
+          <label className="w-full form-control">
+            <div className="label">
+              <span className="label-text">Visibility</span>
+            </div>
+            <select
+              className="w-full select select-bordered"
+              value={visibility}
+              onChange={(e) => {
+                const nextVisibility = e.target.value;
+                setVisibility(nextVisibility);
+                if (nextVisibility !== 'private') {
+                  setMinimumVisibleRole('');
+                }
+              }}
+            >
+              <option value="public">Public</option>
+              <option value="private">Private</option>
+            </select>
+          </label>
+        </div>
+
+        {visibility === 'private' && (
+          <label className="w-full form-control">
+            <div className="label">
+              <span className="label-text">Minimum visible role</span>
+            </div>
+            <select
+              className="w-full max-w-xs select select-bordered"
+              value={minimumVisibleRole}
+              onChange={(e) => setMinimumVisibleRole(e.target.value)}
+            >
+              <option value="">Select role</option>
+              <option value="member">Member</option>
+              <option value="officer">Officer</option>
+              <option value="admin">Admin</option>
+            </select>
+          </label>
+        )}
       </div>
 
       <h2 className="mb-3 text-xl font-semibold text-gray-900 dark:text-white">

--- a/src/Pages/Events/EditEventPage.js
+++ b/src/Pages/Events/EditEventPage.js
@@ -56,6 +56,9 @@ export default function EditEventPage() {
   const [time, setTime] = useState('');
   const [location, setLocation] = useState('');
   const [description, setDescription] = useState('');
+  const [status, setStatus] = useState('draft');
+  const [visibility, setVisibility] = useState('public');
+  const [minimumVisibleRole, setMinimumVisibleRole] = useState('');
   const [maxAttendees, setMaxAttendees] = useState(UNLIMITED_ATTENDEES);
   const [questions, setQuestions] = useState([]);
   const [eventAdmins, setEventAdmins] = useState([]);
@@ -83,7 +86,12 @@ export default function EditEventPage() {
       setTime(evt.time || '');
       setLocation(evt.location || '');
       setDescription(evt.description || '');
-      setMaxAttendees(evt.max_attendees || UNLIMITED_ATTENDEES);
+      setStatus(evt.status || 'draft');
+      setVisibility(evt.visibility || 'public');
+      setMinimumVisibleRole(evt.minimum_visible_role || '');
+      setMaxAttendees(
+        typeof evt.max_attendees === 'number' ? evt.max_attendees : UNLIMITED_ATTENDEES,
+      );
       setQuestions(evt.registration_form || []);
       setEventAdmins(evt.admins || []);
     }
@@ -172,6 +180,11 @@ export default function EditEventPage() {
       return;
     }
 
+    if (visibility === 'private' && !minimumVisibleRole) {
+      setSubmitError('Please select a minimum visible role for private events.');
+      return;
+    }
+
     const payload = {
       name: eventName.trim(),
       date,
@@ -181,6 +194,9 @@ export default function EditEventPage() {
       registration_form: toApiRegistrationForm(questions),
       max_attendees:
         maxAttendees === UNLIMITED_ATTENDEES ? UNLIMITED_ATTENDEES : Number(maxAttendees),
+      status,
+      visibility,
+      minimum_visible_role: visibility === 'private' ? minimumVisibleRole : '',
     };
 
     setSubmitting(true);
@@ -249,6 +265,7 @@ export default function EditEventPage() {
     );
   }
 
+  // Edit access: only users listed in event.admins can update an event
   const isEventAdmin = eventAdmins.includes(userId);
   if (!isEventAdmin) {
     return (
@@ -360,6 +377,61 @@ export default function EditEventPage() {
             placeholder="No limit"
           />
         </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="w-full form-control">
+            <div className="label">
+              <span className="label-text">Publish status</span>
+            </div>
+            <select
+              className="w-full select select-bordered"
+              value={status}
+              onChange={(e) => setStatus(e.target.value)}
+            >
+              <option value="draft">Draft</option>
+              <option value="published">Published</option>
+              <option value="closed">Closed</option>
+            </select>
+          </label>
+
+          <label className="w-full form-control">
+            <div className="label">
+              <span className="label-text">Visibility</span>
+            </div>
+            <select
+              className="w-full select select-bordered"
+              value={visibility}
+              onChange={(e) => {
+                const nextVisibility = e.target.value;
+                setVisibility(nextVisibility);
+                if (nextVisibility !== 'private') {
+                  setMinimumVisibleRole('');
+                }
+              }}
+            >
+              <option value="public">Public</option>
+              <option value="private">Private</option>
+            </select>
+          </label>
+        </div>
+
+        {visibility === 'private' && (
+          <label className="w-full form-control">
+            <div className="label">
+              <span className="label-text">Minimum visible role</span>
+            </div>
+            <select
+              className="w-full max-w-xs select select-bordered"
+              value={minimumVisibleRole}
+              onChange={(e) => setMinimumVisibleRole(e.target.value)}
+            >
+              <option value="">Select role</option>
+              <option value="member">Member</option>
+              <option value="officer">Officer</option>
+              <option value="admin">Admin</option>
+            </select>
+          </label>
+        )}
       </div>
 
       <h2 className="mb-3 text-xl font-semibold text-gray-900 dark:text-white">

--- a/src/Pages/Events/Events.js
+++ b/src/Pages/Events/Events.js
@@ -74,8 +74,49 @@ function EditIcon() {
   );
 }
 
+function getUserAccessLevel(user) {
+  return user?.accessLevel ?? membershipState.NON_MEMBER;
+}
+
+function canUserSeeEvent(event, user) {
+  const userId = user?._id != null ? String(user._id) : '';
+  const userAccess = getUserAccessLevel(user);
+
+  const isGlobalAdmin = userAccess >= membershipState.ADMIN;
+  const isEventAdmin = Array.isArray(event.admins) && userId
+    ? event.admins.includes(userId)
+    : false;
+
+  const status = event.status || 'draft';
+  const visibility = event.visibility || 'public';
+  const minimumVisibleRole = event.minimum_visible_role || '';
+
+  // Draft events are only visible to global admins or users listed in event.admins
+  if (status === 'draft') {
+    return isGlobalAdmin || isEventAdmin;
+  }
+
+  // Public → everyone
+  if (visibility === 'public') {
+    return true;
+  }
+
+  // Private → compare access levels directly
+  if (visibility === 'private') {
+    const requiredLevel = membershipState[minimumVisibleRole?.toUpperCase()];
+    if (requiredLevel === undefined) return false;
+
+    return userAccess >= requiredLevel;
+  }
+
+  return false;
+}
+
 function EventCard({ event, user }) {
-  const isAdmin = event.admins && user?._id && event.admins.includes(String(user._id));
+  const isEventAdmin =
+    Array.isArray(event.admins) && user?._id
+      ? event.admins.includes(String(user._id))
+      : false;
 
   return (
     <div className="group relative flex flex-col rounded-2xl border border-white/10 bg-white/5 p-6 shadow-md backdrop-blur-sm transition duration-300 hover:-translate-y-1 hover:border-white/20 hover:bg-white/[0.07]">
@@ -83,7 +124,7 @@ function EventCard({ event, user }) {
         <h2 className="mb-4 pr-4 text-2xl font-bold text-white">
           {event.name || 'Untitled Event'}
         </h2>
-        {isAdmin && (
+        {isEventAdmin && (
           <Link
             to={`/events/${event.id}/edit`}
             className="rounded-lg p-2 text-gray-400 hover:bg-white/10 hover:text-emerald-400 transition-colors duration-200"
@@ -91,6 +132,19 @@ function EventCard({ event, user }) {
           >
             <EditIcon />
           </Link>
+        )}
+      </div>
+
+      <div className="mb-4 flex flex-wrap gap-2">
+        {event.status === 'draft' && (
+          <span className="rounded-full bg-yellow-500/15 px-3 py-1 text-xs font-medium text-yellow-200 border border-yellow-400/20">
+            Draft
+          </span>
+        )}
+        {event.visibility === 'private' && (
+          <span className="rounded-full bg-purple-500/15 px-3 py-1 text-xs font-medium text-purple-200 border border-purple-400/20">
+            Private
+          </span>
         )}
       </div>
 
@@ -139,6 +193,7 @@ export default function EventsPage() {
   const [hasError, setHasError] = useState(false);
   const isSCEventsEnabled = config.SCEvents?.ENABLED;
   const canCreateEvent = user?.accessLevel >= membershipState.OFFICER;
+  const visibleEvents = events.filter((event) => canUserSeeEvent(event, user));
 
   useEffect(() => {
     if (!isSCEventsEnabled) {
@@ -210,15 +265,15 @@ export default function EventsPage() {
           </div>
         )}
 
-        {!isLoading && !hasError && events.length === 0 && (
+        {!isLoading && !hasError && visibleEvents.length === 0 && (
           <div className="rounded-2xl border border-white/10 bg-white/5 p-10 text-center text-lg text-gray-300">
             No events available right now.
           </div>
         )}
 
-        {!isLoading && !hasError && events.length > 0 && (
+        {!isLoading && !hasError && visibleEvents.length > 0 && (
           <div className="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
-            {events.map((event) => (
+            {visibleEvents.map((event) => (
               <EventCard key={event.id} event={event} user={user} />
             ))}
           </div>


### PR DESCRIPTION
Closes #2082

### Changes
- Added `status`, `visibility`, and `minimum_visible_role` fields to:
  - Create Event page
  - Edit Event page
- Added frontend filtering for SCEvents event cards based on:
  - draft vs published
  - public vs private
  - minimum visible role
- Kept edit access aligned with the current SCEvents backend:
  - only event admins can edit events

### Current visibility behavior

| User type | Published + Public | Published + Private (member) | Published + Private (officer) | Draft |
|---|---:|---:|---:|---:|
| Non-member | ✅ | ❌ | ❌ | ❌ |
| Member | ✅ | ✅ | ❌ | ❌ |
| Officer (not event admin) | ✅ | ✅ | ✅ | ❌ |
| Event admin | ✅ | ✅ | ✅ | ✅ |
| Admin | ✅ | ✅ | ✅ | ✅ |

### Current edit behavior

| User type | Can edit event |
|---|---:|
| Non-member | ❌ |
| Member | ❌ |
| Officer (not event admin) | ❌ |
| Event admin | ✅ |
| Admin (not event admin) | ❌ |

### Verification
- feature flag OFF
<img width="1920" height="931" alt="Screenshot 2026-04-18 at 2 31 16 AM" src="https://github.com/user-attachments/assets/b13b8a59-af27-41fc-941b-0ed84ebf40d7" />
<img width="1920" height="931" alt="Screenshot 2026-04-18 at 2 31 06 AM" src="https://github.com/user-attachments/assets/d601cbb2-0a26-4191-a398-ecb31c343a0b" />

- feature flag ON
   - Public / Non-member
Only public published events are visible
<img width="1920" height="931" alt="Screenshot 2026-04-18 at 2 21 19 AM" src="https://github.com/user-attachments/assets/08c6b64b-192f-47f9-ae37-ccfb905b0082" />

   - Member
<img width="1920" height="931" alt="Screenshot 2026-04-18 at 2 28 43 AM" src="https://github.com/user-attachments/assets/baaa2e51-b483-4d88-8547-49ed1225318a" />

   - Officer (event creator)
Draft event is visible and editable
<img width="1920" height="931" alt="Screenshot 2026-04-18 at 2 21 43 AM" src="https://github.com/user-attachments/assets/70220dc0-0c4a-4164-b34f-705e90edb86d" />

   - Another officer (not event admin)
<img width="1920" height="931" alt="Screenshot 2026-04-18 at 2 22 15 AM" src="https://github.com/user-attachments/assets/dbf471f3-6965-4a39-8af6-5b1e9b73a320" />

   - Admin
<img width="1920" height="931" alt="Screenshot 2026-04-18 at 2 23 22 AM" src="https://github.com/user-attachments/assets/8c138e16-464d-4b35-b22a-16b3e8ac3f53" />
Draft event is visible, but edit is restricted to event admins
<img width="1920" height="931" alt="Screenshot 2026-04-18 at 2 23 29 AM" src="https://github.com/user-attachments/assets/055d6404-7342-4210-9e6a-fa8fae423ef9" />