### PR TITLE
Rename navbar label from SCEvents to Events

### DIFF
--- a/src/Components/Navbar/AdminNavbar.js
+++ b/src/Components/Navbar/AdminNavbar.js
@@ -46,7 +46,7 @@ export default function UserNavBar(props) {
   const sceventsAdminNavLinks = [];
   if (config.SCEvents?.ENABLED) {
     sceventsAdminNavLinks.push({
-      title: 'SCEvents',
+      title: 'Events',
       route: '/events',
       icon: (
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6">

--- a/src/Components/Navbar/UserNavbar.js
+++ b/src/Components/Navbar/UserNavbar.js
@@ -15,14 +15,14 @@ export default function UserNavbar(props) {
     { title: 'About', route: '/about' },
     { title: 'Projects', route: '/projects' },
     { title: 'Summer Internship', route: '/s/internship', newTab: true },
-    ...(config.SCEvents?.ENABLED ? [{ title: 'SCEvents', route: '/events' }] : []),
+    ...(config.SCEvents?.ENABLED ? [{ title: 'Events', route: '/events' }] : []),
   ];
 
   const authedRoutes = [
     { title: 'Printing', route: '/2DPrinting' },
     { title: 'Chat', route: '/messaging' },
     { title: 'LED Sign', route: '/led-sign' },
-    ...(config.SCEvents?.ENABLED ? [{ title: 'SCEvents', route: '/events' }] : []),
+    ...(config.SCEvents?.ENABLED ? [{ title: 'Events', route: '/events' }] : []),
   ];
 
   const authentication = [


### PR DESCRIPTION
### Changes
- Renamed `SCEvents` → `Events` in:
  - signed-out navbar
  - signed-in navbar
  - admin sidebar

### Testing
- signed-out navbar shows `Events`
<img width="1920" height="931" alt="Screenshot 2026-04-23 at 9 13 36 PM" src="https://github.com/user-attachments/assets/08b06d27-62db-4660-a878-002fdcf42802" />

- signed-in navbar shows `Events`
<img width="1920" height="931" alt="Screenshot 2026-04-23 at 9 13 52 PM" src="https://github.com/user-attachments/assets/75563ce0-4177-4a87-bc02-d654c53c45f4" />

- admin sidebar shows `Events`
<img width="1920" height="931" alt="Screenshot 2026-04-23 at 9 14 04 PM" src="https://github.com/user-attachments/assets/21e883b8-080a-41cf-92a3-fae9d8256fca" />