### PR TITLE
Add SCEvents calendar UI and event modal

### DIFF
--- a/src/Pages/Events/CalendarView.js
+++ b/src/Pages/Events/CalendarView.js
@@ -294,7 +294,7 @@ function EventPopup({ event, onClose, isAdminView, user }) {
 
         <div className="space-y-3 border-t border-slate-700/70 px-5 py-4">
           {event.date && (
-            <div className="flex items-start gap-2.5 text-sm text-slate-200">
+            <div className="flex items-start gap-2.5 text-[15px] text-slate-200">
               <span className="mt-0.5 text-slate-400"><CalendarIcon /></span>
               <span>{formatDate(event.date)}</span>
             </div>
@@ -380,7 +380,7 @@ function EventPill({ event, onSelect, isAdminView }) {
       onClick={() => onSelect(event)}
       className={[
         'flex w-full items-start gap-1.5 rounded-md border px-1.5 py-1',
-        'text-left text-[11px] font-semibold leading-tight',
+        'text-left text-[12px] sm:text-[13px] font-semibold leading-tight',
         'transition-all duration-150 hover:border-white/30 hover:brightness-110',
         colors.bg,
         colors.text,
@@ -434,7 +434,7 @@ function CalCell({ date, isCurrentMonth, isToday, events, onSelectEvent, isAdmin
       <div className="mb-1 flex justify-end">
         <span
           className={[
-            'flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold',
+            'flex h-6 w-6 items-center justify-center rounded-full text-sm font-semibold',
             isToday ? 'bg-cyan-400 text-slate-950' : isCurrentMonth ? 'text-slate-200' : 'text-slate-600',
           ].join(' ')}
         >
@@ -535,7 +535,7 @@ export default function CalendarView({ events, isAdminView = false, user, canCre
                   value={month}
                   onChange={handleMonthChange}
                   aria-label="Select month"
-                  className="h-10 w-full appearance-none rounded-lg border border-slate-400/40 bg-slate-800 px-4 pr-10 text-sm font-semibold text-slate-100 transition hover:border-slate-300 hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-cyan-400"
+                  className="h-10 w-full appearance-none rounded-lg border border-slate-400/40 bg-slate-800 px-4 pr-10 text-[14px] font-semibold text-slate-100 transition hover:border-slate-300 hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-cyan-400"
                 >
                   {MONTHS.map((monthName, index) => (
                     <option key={monthName} value={index} className="bg-slate-900">
@@ -556,7 +556,7 @@ export default function CalendarView({ events, isAdminView = false, user, canCre
                   value={year}
                   onChange={handleYearChange}
                   aria-label="Select year"
-                  className="h-10 w-full appearance-none rounded-lg border border-slate-400/40 bg-slate-800 px-4 pr-10 text-sm font-semibold text-slate-100 transition hover:border-slate-300 hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-cyan-400"
+                  className="h-10 w-full appearance-none rounded-lg border border-slate-400/40 bg-slate-800 px-4 pr-10 text-[14px] font-semibold text-slate-100 transition hover:border-slate-300 hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-cyan-400"
                 >
                   {YEAR_RANGE.map((yearOption) => (
                     <option key={yearOption} value={yearOption} className="bg-slate-900">
@@ -574,13 +574,13 @@ export default function CalendarView({ events, isAdminView = false, user, canCre
 
               <button
                 onClick={() => setCursor(new Date(today.getFullYear(), today.getMonth(), 1))}
-                className="h-10 rounded-lg border border-slate-400/40 bg-slate-800 px-4 text-sm font-semibold text-slate-100 transition hover:border-slate-300 hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-cyan-400"
+                className="h-10 rounded-lg border border-slate-400/40 bg-slate-800 px-4 text-[14px] font-semibold text-slate-100 transition hover:border-slate-300 hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-cyan-400"
               >
                 Today
               </button>
             </div>
 
-            <p className="text-xs font-medium tracking-wide text-slate-300">
+            <p className="text-sm font-medium tracking-wide text-slate-300">
               {monthEventCount} event{monthEventCount !== 1 ? 's' : ''} this month
             </p>
           </div>
@@ -590,7 +590,7 @@ export default function CalendarView({ events, isAdminView = false, user, canCre
               <Link
                 to="/events/create"
                 aria-label="Create event"
-                className="inline-flex h-10 items-center justify-center rounded-lg border border-slate-400/40 bg-slate-800 px-3 text-sm font-semibold text-slate-100 transition hover:border-slate-300 hover:bg-slate-700 hover:text-white"
+                className="inline-flex h-10 items-center justify-center rounded-lg border border-slate-400/40 bg-slate-800 px-3 text-[14px] font-semibold text-slate-100 transition hover:border-slate-300 hover:bg-slate-700 hover:text-white"
               >
                 <span className="mr-2"><PlusIcon /></span>
                 Create
@@ -635,7 +635,7 @@ export default function CalendarView({ events, isAdminView = false, user, canCre
               { label: 'Draft', dot: 'bg-amber-300' },
               { label: 'Closed', dot: 'bg-rose-300' },
             ].map(({ label, dot }) => (
-              <span key={label} className="flex items-center gap-1.5 text-[11px] font-medium text-slate-300">
+              <span key={label} className="flex items-center gap-1.5 text-[12px] font-medium text-slate-300">
                 <span className={['h-2 w-2 rounded-full', dot].join(' ')} />
                 {label}
               </span>
@@ -649,7 +649,7 @@ export default function CalendarView({ events, isAdminView = false, user, canCre
               { label: 'Closed', dot: 'bg-rose-300' },
             ].map(({ label, dot }) => (
               <span key={label} className="flex items-center gap-1.5 text-[11px] font-medium text-slate-300">
-                <span className={['h-2 w-2 rounded-full', dot].join(' ')} />
+                <span className={['h-2.5 w-2.5 rounded-full', dot].join(' ')} />
                 {label}
               </span>
             ))}

--- a/src/Pages/Events/CalendarView.js
+++ b/src/Pages/Events/CalendarView.js
@@ -1,0 +1,633 @@
+import React, { useState, useMemo, useEffect, useRef } from 'react';
+import { Link } from 'react-router-dom';
+
+// ─── tiny helpers ────────────────────────────────────────────────────────────
+
+const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const MONTHS = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+const YEAR_RANGE = Array.from({ length: 10 }, (_, i) => 2026 + i);
+
+function toDateKey(date) {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function eventDateKey(event) {
+  if (!event.date) return null;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(event.date)) return event.date;
+  const d = new Date(event.date);
+  if (isNaN(d)) return null;
+  return toDateKey(d);
+}
+
+function formatDate(dateStr) {
+  if (!dateStr) return '';
+  const d = new Date(`${dateStr}T12:00:00`);
+  if (isNaN(d)) return dateStr;
+  return d.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function formatTime(timeStr) {
+  if (!timeStr) return '';
+  const [hours, minutes] = String(timeStr).split(':');
+  if (hours == null || minutes == null) return timeStr;
+
+  const h = Number(hours);
+  const m = Number(minutes);
+  if (Number.isNaN(h) || Number.isNaN(m)) return timeStr;
+
+  return new Date(2000, 0, 1, h, m).toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function pillColors(event, isAdminView) {
+  const status = event.status || 'draft';
+  const visibility = event.visibility || 'public';
+
+  if (isAdminView) {
+    if (status === 'draft') {
+      return {
+        bg: 'bg-amber-500/12',
+        text: 'text-amber-200',
+        border: 'border-amber-400/40',
+        dot: 'bg-amber-300',
+        accent: 'text-amber-300',
+      };
+    }
+
+    if (status === 'closed') {
+      return {
+        bg: 'bg-rose-500/12',
+        text: 'text-rose-200',
+        border: 'border-rose-400/40',
+        dot: 'bg-rose-300',
+        accent: 'text-rose-300',
+      };
+    }
+
+    if (visibility === 'private') {
+      return {
+        bg: 'bg-violet-500/12',
+        text: 'text-violet-200',
+        border: 'border-violet-400/40',
+        dot: 'bg-violet-300',
+        accent: 'text-violet-300',
+      };
+    }
+
+    return {
+      bg: 'bg-cyan-500/12',
+      text: 'text-cyan-100',
+      border: 'border-cyan-400/40',
+      dot: 'bg-cyan-300',
+      accent: 'text-cyan-300',
+    };
+  }
+
+  if (status === 'closed') {
+    return {
+      bg: 'bg-rose-500/16',
+      text: 'text-rose-200',
+      border: 'border-rose-400/30',
+      dot: 'bg-rose-300',
+      accent: 'text-rose-300',
+    };
+  }
+
+  if (visibility === 'private') {
+    return {
+      bg: 'bg-violet-500/16',
+      text: 'text-violet-200',
+      border: 'border-violet-400/30',
+      dot: 'bg-violet-300',
+      accent: 'text-violet-300',
+    };
+  }
+
+  return {
+    bg: 'bg-cyan-500/16',
+    text: 'text-cyan-100',
+    border: 'border-cyan-400/30',
+    dot: 'bg-cyan-300',
+    accent: 'text-cyan-300',
+  };
+}
+
+function getBadgeText(event, isAdminView) {
+  const status = event.status || 'draft';
+  const visibility = event.visibility || 'public';
+
+  if (isAdminView) {
+    if (status === 'draft') return 'Draft';
+    if (status === 'closed') return 'Closed';
+    if (visibility === 'private') return 'Private';
+    return 'Published';
+  }
+
+  if (status === 'closed') return 'Closed';
+  if (visibility === 'private') return 'Members only';
+  return '';
+}
+
+// ─── icons ────────────────────────────────────────────────────────────────────
+
+function ChevronLeft() {
+  return (
+    <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M15 18l-6-6 6-6" />
+    </svg>
+  );
+}
+
+function ChevronRight() {
+  return (
+    <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M9 18l6-6-6-6" />
+    </svg>
+  );
+}
+
+function CalendarIcon() {
+  return (
+    <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="3" y="4" width="18" height="17" rx="2" />
+      <path d="M8 2v4M16 2v4M3 10h18" />
+    </svg>
+  );
+}
+
+function PinIcon() {
+  return (
+    <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M12 21s6-5.686 6-11a6 6 0 1 0-12 0c0 5.314 6 11 6 11Z" />
+      <circle cx="12" cy="10" r="2.5" />
+    </svg>
+  );
+}
+
+function ClockIcon() {
+  return (
+    <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 7v5l3 3" />
+    </svg>
+  );
+}
+
+function XIcon() {
+  return (
+    <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M18 6L6 18M6 6l12 12" />
+    </svg>
+  );
+}
+
+// ─── Event popup ──────────────────────────────────────────────────────────────
+
+function EventPopup({ event, onClose, isAdminView, user }) {
+  const popupRef = useRef(null);
+  const colors = pillColors(event, isAdminView);
+  const badgeText = getBadgeText(event, isAdminView);
+  const userId = user?._id != null ? String(user._id) : '';
+  const canEditEvent =
+    Array.isArray(event.admins) &&
+    userId &&
+    event.admins.includes(userId);
+
+  useEffect(() => {
+    function onKey(e) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  useEffect(() => {
+    function onClickOutside(e) {
+      if (popupRef.current && !popupRef.current.contains(e.target)) {
+        onClose();
+      }
+    }
+    const timer = setTimeout(() => document.addEventListener('mousedown', onClickOutside), 0);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('mousedown', onClickOutside);
+    };
+  }, [onClose]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/35 p-4">
+      <div
+        ref={popupRef}
+        className="relative w-full max-w-sm rounded-xl border border-slate-400/35 bg-slate-900/95 shadow-lg"
+        role="dialog"
+        aria-modal="true"
+        aria-label={event.name}
+      >
+        <div className={['h-1 w-full rounded-t-xl', colors.dot].join(' ')} />
+
+        <div className="flex items-start justify-between px-5 pb-3 pt-4">
+          <div className="flex items-center gap-2">
+            <span className={['h-2.5 w-2.5 shrink-0 rounded-full', colors.dot].join(' ')} />
+            <span className={['text-xs font-semibold uppercase tracking-wider', colors.accent].join(' ')}>
+              {event.category || event.type || 'Event'}
+            </span>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-md p-1 text-slate-400 transition hover:bg-slate-700/70 hover:text-white"
+            aria-label="Close"
+          >
+            <XIcon />
+          </button>
+        </div>
+
+        <div className="px-5 pb-4">
+          <h3 className="text-lg font-bold leading-snug text-white">
+            {event.name || 'Untitled Event'}
+          </h3>
+
+          {badgeText && (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              <span
+                className={[
+                  'rounded-full border px-2 py-0.5 text-[10px] font-medium',
+                  colors.border,
+                  colors.bg,
+                  colors.text,
+                ].join(' ')}
+              >
+                {badgeText}
+              </span>
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-3 border-t border-slate-700/70 px-5 py-4">
+          {event.date && (
+            <div className="flex items-start gap-2.5 text-sm text-slate-200">
+              <span className="mt-0.5 text-slate-400"><CalendarIcon /></span>
+              <span>{formatDate(event.date)}</span>
+            </div>
+          )}
+
+          {event.time && (
+            <div className="flex items-start gap-2.5 text-sm text-slate-200">
+              <span className="mt-0.5 text-slate-400"><ClockIcon /></span>
+              <span>{formatTime(event.time)}</span>
+            </div>
+          )}
+
+          {event.location && (
+            <div className="flex items-start gap-2.5 text-sm text-slate-200">
+              <span className="mt-0.5 text-slate-400"><PinIcon /></span>
+              <span>{event.location}</span>
+            </div>
+          )}
+
+          {event.description && (
+            <p className="pt-1 text-sm leading-relaxed text-slate-300">
+              {event.description}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-2 border-t border-slate-700/70 px-5 py-4">
+          {event.max_attendees > 0 && (
+            <p className="text-center text-xs text-slate-400">
+              {event.max_attendees} spot{event.max_attendees !== 1 ? 's' : ''} available
+              {event.waitlist_enabled && (
+                <span className="ml-1 text-amber-300">· waitlist enabled</span>
+              )}
+            </p>
+          )}
+
+          {canEditEvent && (
+            <Link
+              to={`/events/${event.id}/edit`}
+              className="inline-flex w-full items-center justify-center rounded-xl border border-slate-400/40 bg-slate-800 px-6 py-2.5 text-sm font-semibold text-white transition hover:border-slate-300 hover:bg-slate-700"
+              onClick={onClose}
+            >
+              Edit event
+            </Link>
+          )}
+
+          {!canEditEvent && event.status === 'closed' && (
+            <div className="inline-flex w-full cursor-not-allowed items-center justify-center rounded-xl border border-slate-600/60 bg-slate-800/70 px-6 py-2.5 text-sm font-semibold text-slate-400">
+              Registration closed
+            </div>
+          )}
+
+          {!canEditEvent && event.status === 'draft' && (
+            <div className="inline-flex w-full cursor-not-allowed items-center justify-center rounded-xl border border-yellow-400/20 bg-yellow-500/10 px-6 py-2.5 text-sm font-semibold text-yellow-300">
+              Not yet published
+            </div>
+          )}
+
+          {!canEditEvent && event.status === 'published' && (
+            <Link
+              to={`/events/${event.id}/register`}
+              className="inline-flex w-full items-center justify-center rounded-xl bg-gradient-to-r from-sky-500 to-indigo-500 px-6 py-2.5 text-sm font-semibold text-white transition-all duration-200 hover:from-sky-400 hover:to-indigo-400 focus:outline-none focus:ring-2 focus:ring-sky-500"
+              onClick={onClose}
+            >
+              Register
+            </Link>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Event pill ───────────────────────────────────────────────────────────────
+
+function EventPill({ event, onSelect, isAdminView }) {
+  const colors = pillColors(event, isAdminView);
+  const badgeText = getBadgeText(event, isAdminView);
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(event)}
+      className={[
+        'flex w-full items-start gap-1.5 rounded-md border px-1.5 py-1',
+        'text-left text-[11px] font-semibold leading-tight',
+        'transition-all duration-150 hover:border-white/30 hover:brightness-110',
+        colors.bg,
+        colors.text,
+        colors.border,
+      ].join(' ')}
+      title={event.name}
+    >
+      <span className={['mt-1 h-1.5 w-1.5 shrink-0 rounded-full', colors.dot].join(' ')} />
+      <div className="min-w-0 flex-1">
+        <div className="truncate">
+          {event.name || 'Untitled'}
+        </div>
+        {badgeText && (
+          <div className="truncate pt-0.5 text-[10px] opacity-80">
+            {badgeText}
+          </div>
+        )}
+      </div>
+    </button>
+  );
+}
+
+// ─── Day labels ───────────────────────────────────────────────────────────────
+
+function DayLabels() {
+  return (
+    <div className="grid grid-cols-7 border-b border-slate-700/70 bg-slate-900/35">
+      {DAYS.map((d) => (
+        <div
+          key={d}
+          className="py-2 text-center text-[10px] font-bold uppercase tracking-[0.22em] text-slate-400"
+        >
+          {d}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ─── Calendar cell ────────────────────────────────────────────────────────────
+
+function CalCell({ date, isCurrentMonth, isToday, events, onSelectEvent, isAdminView }) {
+  return (
+    <div
+      className={[
+        'min-h-[100px] border-b border-r border-slate-700/60 p-1.5 transition-colors duration-150',
+        isCurrentMonth ? '' : 'opacity-30',
+        isToday ? 'bg-cyan-500/[0.12]' : 'hover:bg-slate-700/35',
+      ].join(' ')}
+    >
+      <div className="mb-1 flex justify-end">
+        <span
+          className={[
+            'flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold',
+            isToday ? 'bg-cyan-400 text-slate-950' : isCurrentMonth ? 'text-slate-200' : 'text-slate-600',
+          ].join(' ')}
+        >
+          {date.getDate()}
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-0.5">
+        {events.slice(0, 3).map((ev) => (
+          <EventPill
+            key={ev.id}
+            event={ev}
+            onSelect={onSelectEvent}
+            isAdminView={isAdminView}
+          />
+        ))}
+
+        {events.length > 3 && (
+          <span className="pl-1 text-[10px] text-slate-400">
+            +{events.length - 3} more
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Main export ──────────────────────────────────────────────────────────────
+
+export default function CalendarView({ events, isAdminView = false, user }) {
+  const today = new Date();
+  const [cursor, setCursor] = useState(() => new Date(today.getFullYear(), today.getMonth(), 1));
+  const [selectedEvent, setSelectedEvent] = useState(null);
+
+  const eventsByDate = useMemo(() => {
+    const map = {};
+    events.forEach((ev) => {
+      const key = eventDateKey(ev);
+      if (!key) return;
+      if (!map[key]) map[key] = [];
+      map[key].push(ev);
+    });
+    return map;
+  }, [events]);
+
+  const year = cursor.getFullYear();
+  const month = cursor.getMonth();
+
+  function handleMonthChange(e) {
+    const nextMonth = Number(e.target.value);
+    setCursor(new Date(year, nextMonth, 1));
+  }
+
+  function handleYearChange(e) {
+    const nextYear = Number(e.target.value);
+    setCursor(new Date(nextYear, month, 1));
+  }
+
+  const firstDayOfMonth = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const totalCells = Math.ceil((firstDayOfMonth + daysInMonth) / 7) * 7;
+  const todayKey = toDateKey(today);
+
+  const cells = Array.from({ length: totalCells }, (_, i) => {
+    const dayOffset = i - firstDayOfMonth;
+    const date = new Date(year, month, dayOffset + 1);
+    const key = toDateKey(date);
+    return {
+      date,
+      key,
+      isCurrentMonth: date.getMonth() === month,
+      isToday: key === todayKey,
+      events: eventsByDate[key] || [],
+    };
+  });
+
+  const monthEventCount = cells
+    .filter((c) => c.isCurrentMonth)
+    .reduce((sum, c) => sum + c.events.length, 0);
+
+  return (
+    <>
+      {selectedEvent && (
+        <EventPopup
+          event={selectedEvent}
+          onClose={() => setSelectedEvent(null)}
+          isAdminView={isAdminView}
+          user={user}
+        />
+      )}
+
+      <div className="overflow-hidden rounded-xl border border-slate-500/50 bg-slate-800/85 shadow-[0_0_0_1px_rgba(148,163,184,0.05)]">
+        <div className="flex items-start justify-between border-b border-slate-600/50 px-5 py-4">
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center gap-3">
+              <div className="relative w-28 sm:w-36">
+                <select
+                  value={month}
+                  onChange={handleMonthChange}
+                  aria-label="Select month"
+                  className="h-10 w-full appearance-none rounded-lg border border-slate-400/40 bg-slate-800 px-4 pr-10 text-sm font-semibold text-slate-100 transition hover:border-slate-300 hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-cyan-400"
+                >
+                  {MONTHS.map((monthName, index) => (
+                    <option key={monthName} value={index} className="bg-slate-900">
+                      {monthName}
+                    </option>
+                  ))}
+                </select>
+
+                <div className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-slate-300">
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7" />
+                  </svg>
+                </div>
+              </div>
+
+              <div className="relative w-24">
+                <select
+                  value={year}
+                  onChange={handleYearChange}
+                  aria-label="Select year"
+                  className="h-10 w-full appearance-none rounded-lg border border-slate-400/40 bg-slate-800 px-4 pr-10 text-sm font-semibold text-slate-100 transition hover:border-slate-300 hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-cyan-400"
+                >
+                  {YEAR_RANGE.map((yearOption) => (
+                    <option key={yearOption} value={yearOption} className="bg-slate-900">
+                      {yearOption}
+                    </option>
+                  ))}
+                </select>
+
+                <div className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-slate-300">
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7" />
+                  </svg>
+                </div>
+              </div>
+
+              <button
+                onClick={() => setCursor(new Date(today.getFullYear(), today.getMonth(), 1))}
+                className="h-10 rounded-lg border border-slate-400/40 bg-slate-800 px-4 text-sm font-semibold text-slate-100 transition hover:border-slate-300 hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-cyan-400"
+              >
+                Today
+              </button>
+            </div>
+
+            <p className="text-xs font-medium tracking-wide text-slate-300">
+              {monthEventCount} event{monthEventCount !== 1 ? 's' : ''} this month
+            </p>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setCursor(new Date(year, month - 1, 1))}
+              aria-label="Previous month"
+              className="flex h-8 w-8 items-center justify-center rounded-lg border border-slate-400/40 bg-slate-800 text-slate-100 transition hover:border-slate-300 hover:bg-slate-700 hover:text-white"
+            >
+              <ChevronLeft />
+            </button>
+            <button
+              onClick={() => setCursor(new Date(year, month + 1, 1))}
+              aria-label="Next month"
+              className="flex h-8 w-8 items-center justify-center rounded-lg border border-slate-400/40 bg-slate-800 text-slate-100 transition hover:border-slate-300 hover:bg-slate-700 hover:text-white"
+            >
+              <ChevronRight />
+            </button>
+          </div>
+        </div>
+
+        <DayLabels />
+
+        <div className="grid grid-cols-7 [&>*:nth-child(7n)]:border-r-0">
+          {cells.map((cell) => (
+            <CalCell
+              key={cell.key}
+              {...cell}
+              onSelectEvent={setSelectedEvent}
+              isAdminView={isAdminView}
+            />
+          ))}
+        </div>
+
+        {isAdminView ? (
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 border-t border-slate-700/70 bg-slate-900/35 px-5 py-3">
+            {[
+              { label: 'Published', dot: 'bg-cyan-300' },
+              { label: 'Private', dot: 'bg-violet-300' },
+              { label: 'Draft', dot: 'bg-amber-300' },
+              { label: 'Closed', dot: 'bg-rose-300' },
+            ].map(({ label, dot }) => (
+              <span key={label} className="flex items-center gap-1.5 text-[11px] font-medium text-slate-300">
+                <span className={['h-2 w-2 rounded-full', dot].join(' ')} />
+                {label}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 border-t border-slate-700/70 bg-slate-900/35 px-5 py-3">
+            {[
+              { label: 'Open', dot: 'bg-cyan-300' },
+              { label: 'Members only', dot: 'bg-violet-300' },
+              { label: 'Closed', dot: 'bg-rose-300' },
+            ].map(({ label, dot }) => (
+              <span key={label} className="flex items-center gap-1.5 text-[11px] font-medium text-slate-300">
+                <span className={['h-2 w-2 rounded-full', dot].join(' ')} />
+                {label}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/Pages/Events/CalendarView.js
+++ b/src/Pages/Events/CalendarView.js
@@ -194,6 +194,23 @@ function XIcon() {
   );
 }
 
+function PlusIcon() {
+  return (
+    <svg
+      className="h-4 w-4"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 5v14M5 12h14" />
+    </svg>
+  );
+}
+
 // ─── Event popup ──────────────────────────────────────────────────────────────
 
 function EventPopup({ event, onClose, isAdminView, user }) {
@@ -409,7 +426,7 @@ function CalCell({ date, isCurrentMonth, isToday, events, onSelectEvent, isAdmin
   return (
     <div
       className={[
-        'min-h-[100px] border-b border-r border-slate-700/60 p-1.5 transition-colors duration-150',
+        'min-h-[120px] sm:min-h-[130px] border-b border-r border-slate-700/60 p-1.5 transition-colors duration-150',
         isCurrentMonth ? '' : 'opacity-30',
         isToday ? 'bg-cyan-500/[0.12]' : 'hover:bg-slate-700/35',
       ].join(' ')}
@@ -447,7 +464,7 @@ function CalCell({ date, isCurrentMonth, isToday, events, onSelectEvent, isAdmin
 
 // ─── Main export ──────────────────────────────────────────────────────────────
 
-export default function CalendarView({ events, isAdminView = false, user }) {
+export default function CalendarView({ events, isAdminView = false, user, canCreateEvent = false }) {
   const today = new Date();
   const [cursor, setCursor] = useState(() => new Date(today.getFullYear(), today.getMonth(), 1));
   const [selectedEvent, setSelectedEvent] = useState(null);
@@ -510,7 +527,7 @@ export default function CalendarView({ events, isAdminView = false, user }) {
       )}
 
       <div className="overflow-hidden rounded-xl border border-slate-500/50 bg-slate-800/85 shadow-[0_0_0_1px_rgba(148,163,184,0.05)]">
-        <div className="flex items-start justify-between border-b border-slate-600/50 px-5 py-4">
+        <div className="flex flex-wrap items-start justify-between gap-3 border-b border-slate-600/50 px-5 py-4">
           <div className="space-y-3">
             <div className="flex flex-wrap items-center gap-3">
               <div className="relative w-28 sm:w-36">
@@ -569,17 +586,28 @@ export default function CalendarView({ events, isAdminView = false, user }) {
           </div>
 
           <div className="flex items-center gap-2">
+            {canCreateEvent && (
+              <Link
+                to="/events/create"
+                aria-label="Create event"
+                className="inline-flex h-10 items-center justify-center rounded-lg border border-slate-400/40 bg-slate-800 px-3 text-sm font-semibold text-slate-100 transition hover:border-slate-300 hover:bg-slate-700 hover:text-white"
+              >
+                <span className="mr-2"><PlusIcon /></span>
+                Create
+              </Link>
+            )}
+
             <button
               onClick={() => setCursor(new Date(year, month - 1, 1))}
               aria-label="Previous month"
-              className="flex h-8 w-8 items-center justify-center rounded-lg border border-slate-400/40 bg-slate-800 text-slate-100 transition hover:border-slate-300 hover:bg-slate-700 hover:text-white"
+              className="flex h-10 w-10 items-center justify-center rounded-lg border border-slate-400/40 bg-slate-800 text-slate-100 transition hover:border-slate-300 hover:bg-slate-700 hover:text-white"
             >
               <ChevronLeft />
             </button>
             <button
               onClick={() => setCursor(new Date(year, month + 1, 1))}
               aria-label="Next month"
-              className="flex h-8 w-8 items-center justify-center rounded-lg border border-slate-400/40 bg-slate-800 text-slate-100 transition hover:border-slate-300 hover:bg-slate-700 hover:text-white"
+              className="flex h-10 w-10 items-center justify-center rounded-lg border border-slate-400/40 bg-slate-800 text-slate-100 transition hover:border-slate-300 hover:bg-slate-700 hover:text-white"
             >
               <ChevronRight />
             </button>

--- a/src/Pages/Events/CalendarView.js
+++ b/src/Pages/Events/CalendarView.js
@@ -8,7 +8,8 @@ const MONTHS = [
   'January', 'February', 'March', 'April', 'May', 'June',
   'July', 'August', 'September', 'October', 'November', 'December',
 ];
-const YEAR_RANGE = Array.from({ length: 10 }, (_, i) => 2026 + i);
+const currentYear = new Date().getFullYear();
+const YEAR_RANGE = Array.from({ length: 10 }, (_, i) => currentYear + i);
 
 function toDateKey(date) {
   const y = date.getFullYear();

--- a/src/Pages/Events/CalendarView.js
+++ b/src/Pages/Events/CalendarView.js
@@ -590,10 +590,9 @@ export default function CalendarView({ events, isAdminView = false, user, canCre
               <Link
                 to="/events/create"
                 aria-label="Create event"
-                className="inline-flex h-10 items-center justify-center rounded-lg border border-slate-400/40 bg-slate-800 px-3 text-[14px] font-semibold text-slate-100 transition hover:border-slate-300 hover:bg-slate-700 hover:text-white"
+                className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-slate-400/40 bg-slate-800 text-slate-100 transition hover:border-slate-300 hover:bg-slate-700 hover:text-white"
               >
-                <span className="mr-2"><PlusIcon /></span>
-                Create
+                <PlusIcon />
               </Link>
             )}
 

--- a/src/Pages/Events/Events.js
+++ b/src/Pages/Events/Events.js
@@ -6,23 +6,6 @@ import { useSCE } from '../../Components/context/SceContext';
 import { membershipState } from '../../Enums';
 import CalendarView from './CalendarView';
 
-// ─── icons ───────────────────────────────────────────────────────────────────
-
-function PlusIcon() {
-  return (
-    <svg
-      className="h-5 w-5 flex-shrink-0"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.8"
-      aria-hidden="true"
-    >
-      <path strokeLinecap="round" strokeLinejoin="round" d="M12 5v14M5 12h14" />
-    </svg>
-  );
-}
-
 // ─── access helpers ───────────────────────────────────────────────────────────
 
 function getUserAccessLevel(user) {
@@ -105,21 +88,8 @@ export default function EventsPage() {
         <div className="absolute right-[-8rem] top-[10rem] h-[24rem] w-[24rem] rounded-full bg-indigo-500/10 blur-3xl" />
       </div>
 
-      {/* ── Create button (officers/admins only) — top-right ── */}
-      {canCreateEvent && (
-        <div className="relative mx-auto max-w-7xl px-6 pt-8 flex justify-end">
-          <Link
-            to="/events/create"
-            aria-label="Create event"
-            className="inline-flex size-10 shrink-0 items-center justify-center rounded-xl border border-white/20 bg-white/10 text-white shadow-sm backdrop-blur transition hover:border-white/30 hover:bg-white/[0.15]"
-          >
-            <PlusIcon />
-          </Link>
-        </div>
-      )}
-
       {/* ── Calendar area ── */}
-      <div className="relative mx-auto max-w-7xl px-6 py-8">
+      <div className="relative mx-auto max-w-[120rem] px-4 py-8 sm:px-6 lg:px-10">
         {isLoading && (
           <div className="py-16 text-center text-lg text-gray-300">
             Loading events...
@@ -133,7 +103,12 @@ export default function EventsPage() {
         )}
 
         {!isLoading && !hasError && (
-          <CalendarView events={visibleEvents} isAdminView={isAdminView} user={user} />
+          <CalendarView
+            events={visibleEvents}
+            isAdminView={isAdminView}
+            user={user}
+            canCreateEvent={canCreateEvent}
+          />
         )}
       </div>
     </div>

--- a/src/Pages/Events/Events.js
+++ b/src/Pages/Events/Events.js
@@ -4,42 +4,9 @@ import { Link, Redirect } from 'react-router-dom';
 import { getAllSCEvents } from '../../APIFunctions/SCEvents';
 import { useSCE } from '../../Components/context/SceContext';
 import { membershipState } from '../../Enums';
+import CalendarView from './CalendarView';
 
-function CalendarIcon() {
-  return (
-    <svg
-      className="h-4 w-4 flex-shrink-0"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.8"
-      aria-hidden="true"
-    >
-      <path strokeLinecap="round" strokeLinejoin="round" d="M8 2v4M16 2v4M3 10h18" />
-      <rect x="3" y="4" width="18" height="17" rx="2" />
-    </svg>
-  );
-}
-
-function PinIcon() {
-  return (
-    <svg
-      className="h-4 w-4 flex-shrink-0"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.8"
-      aria-hidden="true"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M12 21s6-5.686 6-11a6 6 0 1 0-12 0c0 5.314 6 11 6 11Z"
-      />
-      <circle cx="12" cy="10" r="2.5" />
-    </svg>
-  );
-}
+// ─── icons ───────────────────────────────────────────────────────────────────
 
 function PlusIcon() {
   return (
@@ -56,23 +23,7 @@ function PlusIcon() {
   );
 }
 
-function EditIcon() {
-  return (
-    <svg
-      className="h-5 w-5 flex-shrink-0"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.8"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
-      <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
-    </svg>
-  );
-}
+// ─── access helpers ───────────────────────────────────────────────────────────
 
 function getUserAccessLevel(user) {
   return user?.accessLevel ?? membershipState.NON_MEMBER;
@@ -91,114 +42,38 @@ function canUserSeeEvent(event, user) {
   const visibility = event.visibility || 'public';
   const minimumVisibleRole = event.minimum_visible_role || '';
 
-  // Draft events are only visible to global admins or users listed in event.admins
   if (status === 'draft') {
     return isGlobalAdmin || isEventAdmin;
   }
 
-  // Public → everyone
   if (visibility === 'public') {
     return true;
   }
 
-  // Private → compare access levels directly
   if (visibility === 'private') {
     const requiredLevel = membershipState[minimumVisibleRole?.toUpperCase()];
     if (requiredLevel === undefined) return false;
-
     return userAccess >= requiredLevel;
   }
 
   return false;
 }
 
-function EventCard({ event, user }) {
-  const isEventAdmin =
-    Array.isArray(event.admins) && user?._id
-      ? event.admins.includes(String(user._id))
-      : false;
-
-  return (
-    <div className="group relative flex flex-col rounded-2xl border border-white/10 bg-white/5 p-6 shadow-md backdrop-blur-sm transition duration-300 hover:-translate-y-1 hover:border-white/20 hover:bg-white/[0.07]">
-      <div className="flex items-start justify-between">
-        <h2 className="mb-4 pr-4 text-2xl font-bold text-white">
-          {event.name || 'Untitled Event'}
-        </h2>
-        {isEventAdmin && (
-          <Link
-            to={`/events/${event.id}/edit`}
-            className="rounded-lg p-2 text-gray-400 hover:bg-white/10 hover:text-emerald-400 transition-colors duration-200"
-            title="Edit Event"
-          >
-            <EditIcon />
-          </Link>
-        )}
-      </div>
-
-      <div className="mb-4 flex flex-wrap gap-2">
-        {event.status === 'draft' && (
-          <span className="rounded-full bg-yellow-500/15 px-3 py-1 text-xs font-medium text-yellow-200 border border-yellow-400/20">
-            Draft
-          </span>
-        )}
-        {event.visibility === 'private' && (
-          <span className="rounded-full bg-purple-500/15 px-3 py-1 text-xs font-medium text-purple-200 border border-purple-400/20">
-            Private
-          </span>
-        )}
-      </div>
-
-      <div className="mb-5 space-y-2 text-sm text-gray-300">
-        {(event.date || event.time) && (
-          <div className="flex items-center gap-2">
-            <span className="text-blue-300">
-              <CalendarIcon />
-            </span>
-            <span>{[event.date, event.time].filter(Boolean).join(' · ')}</span>
-          </div>
-        )}
-
-        {event.location && (
-          <div className="flex items-center gap-2">
-            <span className="text-blue-300">
-              <PinIcon />
-            </span>
-            <span>{event.location}</span>
-          </div>
-        )}
-      </div>
-
-      {event.description && (
-        <p className="text-base leading-7 text-gray-300">
-          {event.description}
-        </p>
-      )}
-
-      <div className="mt-auto pt-6">
-        <Link
-          to={`/events/${event.id}/register`}
-          className="inline-flex w-full items-center justify-center rounded-xl bg-gradient-to-r from-sky-500 to-indigo-500 px-6 py-3 text-sm font-semibold text-white shadow-lg transition-all duration-300 hover:from-sky-400 hover:to-indigo-400 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 focus:ring-offset-gray-900"
-        >
-          Register
-        </Link>
-      </div>
-    </div>
-  );
-}
+// ─── page ─────────────────────────────────────────────────────────────────────
 
 export default function EventsPage() {
   const { user } = useSCE();
   const [events, setEvents] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
+
   const isSCEventsEnabled = config.SCEvents?.ENABLED;
   const canCreateEvent = user?.accessLevel >= membershipState.OFFICER;
   const visibleEvents = events.filter((event) => canUserSeeEvent(event, user));
+  const isAdminView = canCreateEvent;
 
   useEffect(() => {
-    if (!isSCEventsEnabled) {
-      return;
-    }
+    if (!isSCEventsEnabled) return;
 
     async function fetchEvents() {
       setIsLoading(true);
@@ -224,35 +99,27 @@ export default function EventsPage() {
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-gradient-to-r from-gray-800 to-gray-600 text-white">
+      {/* Ambient blobs — unchanged from original */}
       <div className="pointer-events-none absolute inset-0">
         <div className="absolute -top-24 left-[-8rem] h-[22rem] w-[22rem] rounded-full bg-sky-400/10 blur-3xl" />
         <div className="absolute right-[-8rem] top-[10rem] h-[24rem] w-[24rem] rounded-full bg-indigo-500/10 blur-3xl" />
       </div>
 
-      <div className="relative mx-auto max-w-6xl px-6 py-12">
-        <div className="mb-3 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-          <h1 className="text-4xl font-bold text-white md:text-5xl">
-            SCEvents
-          </h1>
-          {canCreateEvent && (
-            <Link
-              to="/events/create"
-              aria-label="Create event"
-              className="inline-flex size-10 shrink-0 items-center justify-center rounded-xl border border-white/20 bg-white/10 text-white shadow-sm backdrop-blur transition hover:border-white/30 hover:bg-white/[0.15]"
-            >
-              <PlusIcon />
-            </Link>
-          )}
+      {/* ── Create button (officers/admins only) — top-right ── */}
+      {canCreateEvent && (
+        <div className="relative mx-auto max-w-7xl px-6 pt-8 flex justify-end">
+          <Link
+            to="/events/create"
+            aria-label="Create event"
+            className="inline-flex size-10 shrink-0 items-center justify-center rounded-xl border border-white/20 bg-white/10 text-white shadow-sm backdrop-blur transition hover:border-white/30 hover:bg-white/[0.15]"
+          >
+            <PlusIcon />
+          </Link>
         </div>
+      )}
 
-        <div className="mb-6 h-[2px] w-28 rounded-full bg-gradient-to-r from-sky-400 via-blue-400 to-indigo-400" />
-
-        <p className="max-w-2xl text-lg text-gray-300 md:text-xl">
-          Discover upcoming SCE events and activities.
-        </p>
-      </div>
-
-      <div className="relative mx-auto max-w-6xl px-6 pb-14">
+      {/* ── Calendar area ── */}
+      <div className="relative mx-auto max-w-7xl px-6 py-8">
         {isLoading && (
           <div className="py-16 text-center text-lg text-gray-300">
             Loading events...
@@ -265,18 +132,8 @@ export default function EventsPage() {
           </div>
         )}
 
-        {!isLoading && !hasError && visibleEvents.length === 0 && (
-          <div className="rounded-2xl border border-white/10 bg-white/5 p-10 text-center text-lg text-gray-300">
-            No events available right now.
-          </div>
-        )}
-
-        {!isLoading && !hasError && visibleEvents.length > 0 && (
-          <div className="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
-            {visibleEvents.map((event) => (
-              <EventCard key={event.id} event={event} user={user} />
-            ))}
-          </div>
+        {!isLoading && !hasError && (
+          <CalendarView events={visibleEvents} isAdminView={isAdminView} user={user} />
         )}
       </div>
     </div>


### PR DESCRIPTION
Closes #2079
Closes #2081

### Changes
- Implemented a calendar-based UI for SCEvents
- Events are displayed in a month view similar to Google Calendar
- Clicking an event opens a modal with:
  - event details (date, time, location, description)
  - registration CTA (for visible events)
  - edit CTA (for event admins only)
- Added month/year dropdown navigation and previous/next controls
- Improved visibility handling in the UI to match backend logic

### Event interaction behavior
- Public users can view public published events
- Members can view member-visible events
- Officers/admins can see additional events based on permissions
- Draft events are only visible to event admins and admins
- Only event admins can edit events

### Screenshots
#### Public / non-member view
- Only public published events are visible
- Member-only events are visible in addition to public events
<img width="1920" height="1037" alt="Screenshot 2026-04-24 at 2 27 02 AM" src="https://github.com/user-attachments/assets/2f99329c-9618-4542-9eeb-324468470503" />
<img width="1920" height="1037" alt="Screenshot 2026-04-24 at 2 27 09 AM" src="https://github.com/user-attachments/assets/c8de9f68-b904-4043-bc7f-6675a7f243a9" />
<img width="1920" height="1037" alt="Screenshot 2026-04-24 at 2 27 19 AM" src="https://github.com/user-attachments/assets/2287da5b-4ade-4c6e-a3de-ed06c6dbcb3d" />

#### Member view
- Member-only events are visible in addition to public events
<img width="1920" height="1037" alt="Screenshot 2026-04-24 at 2 27 41 AM" src="https://github.com/user-attachments/assets/f74bea97-5f8b-4592-b907-777558db199a" />

#### Officer (not event admin)
- Can view all published events they have access to
- Cannot see or edit draft events they do not own
<img width="1920" height="1037" alt="Screenshot 2026-04-24 at 2 50 45 AM" src="https://github.com/user-attachments/assets/bfb98f30-3666-4af0-b090-3b43144db7c6" />

#### Event admin view
- Can view draft events
- Can edit their own events from the modal
<img width="1920" height="1037" alt="Screenshot 2026-04-24 at 2 47 53 AM" src="https://github.com/user-attachments/assets/fabdf013-e9d5-468c-947f-959bb8eccb6a" />

#### Admin (not event admin)
- Can view draft events
- Cannot edit unless they are listed as an event admin
<img width="1920" height="1037" alt="Screenshot 2026-04-24 at 2 48 31 AM" src="https://github.com/user-attachments/assets/e0aca078-b748-4f67-b5f3-11bad8b5e889" />

#### Calendar UI
- Month view with event pills
- Supports multiple events per day
- Dropdown navigation for month/year
<img width="1920" height="1037" alt="Screenshot 2026-04-24 at 2 29 00 AM" src="https://github.com/user-attachments/assets/e8670cc1-7cac-40ee-8ae2-1adb36b531ad" />
<img width="1920" height="1037" alt="Screenshot 2026-04-24 at 2 29 06 AM" src="https://github.com/user-attachments/assets/81aa2add-b04d-42ca-b8c7-4ebcde23d201" />

### Note
- Mobile month view is functional, but a dedicated responsive layout would be a good follow-up improvement.
<img width="1920" height="1037" alt="Screenshot 2026-04-24 at 2 49 20 AM" src="https://github.com/user-attachments/assets/60628017-369c-438f-9f12-7a4170acec92" />
<img width="1920" height="1037" alt="Screenshot 2026-04-24 at 2 49 27 AM" src="https://github.com/user-attachments/assets/1f0a1eb5-23de-47dc-9de7-c206c456d13a" />