### PR TITLE
Fix SCEta nginx routing

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -78,6 +78,9 @@ http {
             resolver 127.0.0.11 valid=15s;
 
             proxy_set_header   Host $host;
+            proxy_set_header   X-Original-URL "$scheme://$host$request_uri";
+            proxy_set_header   X-Base-URL "$scheme://$host";
+            proxy_set_header   X-Forwarded-Prefix /transit;
             set $upstream http://sceta-nginx.sce;
             proxy_pass $upstream;
 


### PR DESCRIPTION
**CONTEXT**
- SCEta didn't work + was routing to `/frontend`

**CHANGES**
- update nginx to route properly

**TESTING**
- https://sce.sjsu.edu/transit/ works, i changed the `nginx.conf` in the deployed version
<img width="1415" height="637" alt="image" src="https://github.com/user-attachments/assets/6beb0dd3-8ccd-4b50-a6ee-27c995c5c6b7" />
