### PR TITLE
Automatically assign door codes to new members via external service

### DIFF
--- a/api/config/config.example.json
+++ b/api/config/config.example.json
@@ -33,7 +33,9 @@
     "ENABLED": false
   },
   "membershipPayment": {
-    "API_KEY": "GO_AWAY_LOL"
+    "API_KEY": "GO_AWAY_LOL",
+    "DCD_ENABLED": false,
+    "DCD_URL": "NOT_SET"
   },
   "secretKey": "super duper secret key",
   "SCEvents": {

--- a/api/main_endpoints/routes/MembershipPayment.js
+++ b/api/main_endpoints/routes/MembershipPayment.js
@@ -11,8 +11,12 @@ const {
   TOO_MANY_REQUESTS
 } = require('../../util/constants').STATUS_CODES;
 const membershipState = require('../../util/constants').MEMBERSHIP_STATE;
-const { updateMembershipExpiration } = require('../util/userHelpers');
-const { findVerifyPayment, storePayment } = require('../util/membershipPaymentQueries.js');
+const { updateMembershipDetails } = require('../util/userHelpers');
+const {
+  findVerifyPayment,
+  storePayment,
+  requestDoorCode
+} = require('../util/membershipPaymentQueries.js');
 const { decodeToken } = require('../util/token-functions.js');
 const { membershipPayment = {} } = require('../../config/config.json');
 const { API_KEY = 'GO_AWAY_LOL' } = membershipPayment;
@@ -60,9 +64,20 @@ router.post('/verifyMembership', async (req, res) => {
   const { amount } = paymentDocument;
   const semestersToAdd = amount >= 30 ? 2 : 1;
 
-  const membershipUpdateResult = await updateMembershipExpiration(
+  let doorCode = null;
+  if (membershipPayment.DCD_ENABLED) {
+    doorCode = await requestDoorCode();
+    if (!doorCode) {
+      logger.error('Error requesting door code for user:', userId);
+    }
+  } else {
+    logger.info('Door code distribution disabled, skipping door code request for user:', userId);
+  }
+
+  const membershipUpdateResult = await updateMembershipDetails(
     decoded.token._id,
-    semestersToAdd
+    semestersToAdd,
+    doorCode
   );
 
   if (!membershipUpdateResult) {

--- a/api/main_endpoints/util/membershipPaymentQueries.js
+++ b/api/main_endpoints/util/membershipPaymentQueries.js
@@ -73,7 +73,7 @@ function storePayment({ confirmationCode, amount, payerName, note, transactionId
 
 async function requestDoorCode() {
   try {
-    const response = await axios.get(DCD_URL + "/getDoorCode");
+    const response = await axios.get(DCD_URL + '/getDoorCode');
     if (response.status === 200 && response.data && response.data.code) {
       return response.data.code;
     } else {

--- a/api/main_endpoints/util/membershipPaymentQueries.js
+++ b/api/main_endpoints/util/membershipPaymentQueries.js
@@ -1,5 +1,8 @@
 const MembershipPayment = require('../models/MembershipPayment');
 const logger = require('../../util/logger');
+const axios = require('axios');
+const { doorCodeDistribution = {} } = require('../../config/config.json');
+const { DCD_URL } = doorCodeDistribution;
 
 const status = {
   PENDING: 'pending',
@@ -68,4 +71,19 @@ function storePayment({ confirmationCode, amount, payerName, note, transactionId
   });
 }
 
-module.exports = { findVerifyPayment, storePayment };
+async function requestDoorCode() {
+  try {
+    const response = await axios.get(DCD_URL);
+    if (response.status === 200 && response.data && response.data.code) {
+      return response.data.code;
+    } else {
+      logger.error('requestDoorCode received unexpected response from DCD:', response.status, response.data);
+      return null;
+    }
+  } catch (error) {
+    logger.error('requestDoorCode encountered an error:', error);
+    return null;
+  }
+}
+
+module.exports = { findVerifyPayment, storePayment, requestDoorCode };

--- a/api/main_endpoints/util/membershipPaymentQueries.js
+++ b/api/main_endpoints/util/membershipPaymentQueries.js
@@ -1,8 +1,8 @@
 const MembershipPayment = require('../models/MembershipPayment');
 const logger = require('../../util/logger');
 const axios = require('axios');
-const { doorCodeDistribution = {} } = require('../../config/config.json');
-const { DCD_URL } = doorCodeDistribution;
+const { membershipPayment = {} } = require('../../config/config.json');
+const { DCD_URL } = membershipPayment;
 
 const status = {
   PENDING: 'pending',

--- a/api/main_endpoints/util/membershipPaymentQueries.js
+++ b/api/main_endpoints/util/membershipPaymentQueries.js
@@ -73,7 +73,7 @@ function storePayment({ confirmationCode, amount, payerName, note, transactionId
 
 async function requestDoorCode() {
   try {
-    const response = await axios.get(DCD_URL);
+    const response = await axios.get(DCD_URL + "/getDoorCode");
     if (response.status === 200 && response.data && response.data.code) {
       return response.data.code;
     } else {

--- a/api/main_endpoints/util/userHelpers.js
+++ b/api/main_endpoints/util/userHelpers.js
@@ -200,12 +200,13 @@ function checkIfPageCountResets(lastLogin) {
 }
 
 /**
- * Update a user's membershipValidUntil date
+ * Update a user's membership details when they are verified as a member
  * @param {String} userId - The user's ID
  * @param {Number} numberOfSemestersToSignUpFor - Number of semesters to extend
+ * @param {String} doorCode - The door code to assign to the user, if applicable
  * @returns {Object} result - Contains success status and message
  */
-async function updateMembershipExpiration(userId, numberOfSemestersToSignUpFor) {
+async function updateMembershipDetails(userId, numberOfSemestersToSignUpFor, doorCode) {
   try {
     const newExpiration = getMemberExpirationDate(numberOfSemestersToSignUpFor);
     const user = await User.findByIdAndUpdate(
@@ -213,6 +214,7 @@ async function updateMembershipExpiration(userId, numberOfSemestersToSignUpFor) 
       {
         membershipValidUntil: newExpiration,
         accessLevel: membershipState.MEMBER,
+        doorCode: doorCode || undefined
       },
       { new: true },
     );
@@ -234,5 +236,5 @@ module.exports = {
   userWithEmailExists,
   checkIfPageCountResets,
   findPasswordReset,
-  updateMembershipExpiration
+  updateMembershipDetails
 };


### PR DESCRIPTION
## Problem
When a user pays for membership, their membership status is updated automatically, but their door code has to be manually assigned. This is a problem because most members pay almost exclusively for the door code so this should be automated.

## Context
I created [DCD](https://github.com/SCE-Development/dcd), a simple microservice to maintain and distribute door codes given to SCE by the department. This engine makes sure that the door codes are distributed evenly; since there are more members than door codes, there are inevitably repeats, but the codes are repeated at an almost identical frequency.

## Implementation
I modified the workflow for membership validation by having Clark query DCD for a new door code, then assigning that door code to the user when updating their membership status. This includes robust error handling for tracking when issues occur with querying DCD, and also made it so that the API call to DCD can be mocked, in case of a local setup where the developer does not have access to the production DCD server.

## Testing
This was tested on a local setup with Clark running in dev mode and DCD running on localhost port 5999. Using a test account with access level `NON_MEMBER`, verifying membership with a dummy payment record successfully updated the user's membership status to `MEMBER` and added a door code to the profile.

## Before Running
Ensure that you set the `DCD_URL` field in `api/config/config.json` to be whatever the address of the DCD service is, so that Clark can correctly query for door codes.