### PR TITLE
remove create event in admin navbar

### DIFF
--- a/src/Components/Navbar/AdminNavbar.js
+++ b/src/Components/Navbar/AdminNavbar.js
@@ -52,17 +52,6 @@ export default function UserNavBar(props) {
       </svg>
     ),
   });
-  if (user?.accessLevel >= membershipState.OFFICER) {
-    sceventsAdminNavLinks.push({
-      title: 'Create event',
-      route: '/events/create',
-      icon: (
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-        </svg>
-      ),
-    });
-  }
 
   const adminLinks = [
     {


### PR DESCRIPTION
Closes #2110 
Remove Create Event in the admin navbar
<img width="234" height="663" alt="Screenshot 2026-04-28 at 9 47 29 PM" src="https://github.com/user-attachments/assets/0a4e4d4d-2216-44e4-ae06-45973c9f2026" />
