### PR TITLE
Fix SCEvents API functions and add registration/me endpoint support

### DIFF
--- a/src/APIFunctions/SCEvents.js
+++ b/src/APIFunctions/SCEvents.js
@@ -154,11 +154,9 @@ export async function deleteSCEvent(id, token) {
 export async function getEventRegistrations(eventId, token, { limit = 50, offset = 0 } = {}) {
   const status = new ApiResponse();
   try {
-    const url = new URL(`${SCEVENTS_API_URL}/events/${eventId}/registrations`, window.location.origin);
-    url.searchParams.set('limit', String(limit));
-    url.searchParams.set('offset', String(offset));
+    const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
 
-    const res = await fetch(url.href, {
+    const res = await fetch(`${SCEVENTS_API_URL}/events/${eventId}/registrations?${params}`, {
       headers: {
         Authorization: `Bearer ${token}`,
       },
@@ -262,7 +260,7 @@ export async function joinWaitlistForSCEvent(eventId, token) {
     }
   } catch (err) {
     status.error = true;
-    status.responseData = err;
+    status.responseData = { error: err?.message || 'Failed to connect to SCEvents API' };
   }
 
   return status;

--- a/src/APIFunctions/SCEvents.js
+++ b/src/APIFunctions/SCEvents.js
@@ -39,7 +39,8 @@ export async function getEventByID(id, token) {
       ? { Authorization: `Bearer ${token}` }
       : {};
 
-    const res = await fetch(`${SCEVENTS_API_URL}/events/${id}`, {
+    const url = new URL(`${SCEVENTS_API_URL}/events/${id}`, window.location.origin);
+    const res = await fetch(url.href, {
       headers,
     });
 
@@ -58,7 +59,8 @@ export async function getEventByID(id, token) {
 export async function getEventAttendanceSummary(id, token) {
   const status = new ApiResponse();
   try {
-    const res = await fetch(`${SCEVENTS_API_URL}/events/${id}/attendance`, {
+    const url = new URL(`${SCEVENTS_API_URL}/events/${id}/attendance`, window.location.origin);
+    const res = await fetch(url.href, {
       headers: {
         Authorization: `Bearer ${token}`,
       },
@@ -78,7 +80,8 @@ export async function getEventAttendanceSummary(id, token) {
 export async function createSCEvent(token, eventBody) {
   const status = new ApiResponse();
   try {
-    const res = await fetch(`${SCEVENTS_API_URL}/events/`, {
+    const url = new URL(`${SCEVENTS_API_URL}/events/`, window.location.origin);
+    const res = await fetch(url.href, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -101,7 +104,8 @@ export async function createSCEvent(token, eventBody) {
 export async function updateSCEvent(id, token, eventUpdates) {
   const status = new ApiResponse();
   try {
-    const res = await fetch(`${SCEVENTS_API_URL}/events/${id}`, {
+    const url = new URL(`${SCEVENTS_API_URL}/events/${id}`, window.location.origin);
+    const res = await fetch(url.href, {
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
@@ -150,7 +154,7 @@ export async function deleteSCEvent(id, token) {
 export async function getEventRegistrations(eventId, token, { limit = 50, offset = 0 } = {}) {
   const status = new ApiResponse();
   try {
-    const url = new URL(`${SCEVENTS_API_URL}/events/${eventId}/registrations`);
+    const url = new URL(`${SCEVENTS_API_URL}/events/${eventId}/registrations`, window.location.origin);
     url.searchParams.set('limit', String(limit));
     url.searchParams.set('offset', String(offset));
 
@@ -174,7 +178,8 @@ export async function getEventRegistrations(eventId, token, { limit = 50, offset
 export async function getEventRegistrationByRequestId(eventId, requestId, token) {
   const status = new ApiResponse();
   try {
-    const res = await fetch(`${SCEVENTS_API_URL}/events/${eventId}/registrations/${requestId}`, {
+    const url = new URL(`${SCEVENTS_API_URL}/events/${eventId}/registrations/${requestId}`, window.location.origin);
+    const res = await fetch(url.href, {
       headers: {
         Authorization: `Bearer ${token}`,
       },
@@ -194,7 +199,8 @@ export async function getEventRegistrationByRequestId(eventId, requestId, token)
 export async function registerForEvent(eventId, token, payload) {
   const status = new ApiResponse();
   try {
-    const res = await fetch(`${SCEVENTS_API_URL}/events/${eventId}/register`, {
+    const url = new URL(`${SCEVENTS_API_URL}/events/${eventId}/register`, window.location.origin);
+    const res = await fetch(url.href, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -218,7 +224,8 @@ export async function registerForEvent(eventId, token, payload) {
 export async function getMyEventRegistrationState(eventId, token) {
   const status = new ApiResponse();
   try {
-    const res = await fetch(`${SCEVENTS_API_URL}/events/${eventId}/registration/me`, {
+    const url = new URL(`${SCEVENTS_API_URL}/events/${eventId}/registration/me`, window.location.origin);
+    const res = await fetch(url.href, {
       headers: {
         Authorization: `Bearer ${token}`,
       },
@@ -239,7 +246,8 @@ export async function joinWaitlistForSCEvent(eventId, token) {
   const status = new ApiResponse();
 
   try {
-    const res = await fetch(`${SCEVENTS_API_URL}/events/${eventId}/waitlist`, {
+    const url = new URL(`${SCEVENTS_API_URL}/events/${eventId}/waitlist`, window.location.origin);
+    const res = await fetch(url.href, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,


### PR DESCRIPTION
The normal view of the admin of the event:
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/4dd2a329-0932-4b88-ae16-697864be51aa" />

We can fetch api from our backend right now, i dont know why but i think we have sth broken and fetch function:
<img width="2560" height="1382" alt="image" src="https://github.com/user-attachments/assets/3f1014c5-8d7d-472c-9bcc-1d5dbd360eb2" />

The flow work quite normal:
<img width="2555" height="1395" alt="image" src="https://github.com/user-attachments/assets/0cc88424-77d2-407e-82af-4974622e0541" />

We can edit the event right now:
<img width="2560" height="1394" alt="image" src="https://github.com/user-attachments/assets/d899e200-bfd0-431c-a6aa-878cc89a8c60" />

We can see it works: 
<img width="2560" height="1394" alt="image" src="https://github.com/user-attachments/assets/d899e200-bfd0-431c-a6aa-878cc89a8c60" />

Can we update the user registration data UI. It look quite terrible:

<img width="2559" height="1366" alt="image" src="https://github.com/user-attachments/assets/10d945b4-2fd3-46b5-a4e7-f4beb940dad3" />

closes [2121](https://github.com/SCE-Development/Clark/issues/2121)

The Cause: The code was calling new URL('/api/scevents/...'). In JavaScript, if you provide a relative path to the URL constructor, you must provide a base URL as the second argument. -> fix by updating every new URL call in src/APIFunctions/SCEvents.js to include window.location.origin as the base. Idk it yet Can we discuss on Discord ?


