### PR TITLE
Polished event editor spacing

### DIFF
--- a/src/Pages/Events/CreateEventPage.js
+++ b/src/Pages/Events/CreateEventPage.js
@@ -159,7 +159,7 @@ export default function CreateEventPage() {
       meta={{
         title: 'Create event',
         eventIdLabel: eventId,
-        containerClassName: 'm-10 max-w-4xl px-4 sm:px-6',
+        containerClassName: 'mx-auto mt-3 mb-6 w-full max-w-4xl px-3 sm:mt-4 sm:mb-8 sm:px-6 md:mt-5 md:mb-10',
         submitLabel: 'Create event',
         submittingLabel: 'Creating…',
         onSubmit: handleCreateEvent,

--- a/src/Pages/Events/EditEventPage.js
+++ b/src/Pages/Events/EditEventPage.js
@@ -190,7 +190,7 @@ export default function EditEventPage() {
       meta={{
         title: 'Edit event',
         eventIdLabel: id,
-        containerClassName: 'mx-auto my-10 max-w-4xl px-4 sm:px-6',
+        containerClassName: 'mx-auto mt-3 mb-6 w-full max-w-4xl px-3 sm:mt-4 sm:mb-8 sm:px-6 md:mt-5 md:mb-10',
         submitLabel: 'Save changes',
         submittingLabel: 'Updating…',
         onSubmit: handleUpdateEvent,

--- a/src/Pages/Events/EventEditorForm.js
+++ b/src/Pages/Events/EventEditorForm.js
@@ -57,7 +57,7 @@ export default function EventEditorForm({
 
   return (
     <div className={containerClassName}>
-      <div className="mb-8 pb-2 pt-8">
+      <div className="mb-8 pb-2 pt-3">
         <Link to="/events" className="btn btn-ghost mb-4 pl-0 text-base font-medium normal-case text-gray-400 hover:bg-transparent hover:text-white">
           ← Back to Events
         </Link>
@@ -68,7 +68,7 @@ export default function EventEditorForm({
       </div>
 
       <h2 className="mb-3 text-xl font-semibold text-gray-900 dark:text-white">Event details</h2>
-      <div className="mb-10 space-y-4 rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <div className="mb-10 space-y-4 rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800 sm:p-6">
         <label className="form-control w-full">
           <div className="label">
             <span className="label-text">Event name *</span>


### PR DESCRIPTION
# PR for #2122

## Problem 
Usage of space is not the best for SCEvents and we need refactor how it looks a bit

## Solution
Fix space usage in both desktop and mobile mode

## Screenshots

### Monitor View
<img width="2672" height="1521" alt="Screenshot 2026-05-01 at 9 04 13 PM" src="https://github.com/user-attachments/assets/fdbd5fd5-021e-4b14-8ff7-5a001222c994" />

### Laptop View
<img width="1822" height="1184" alt="Screenshot 2026-05-01 at 9 13 18 PM" src="https://github.com/user-attachments/assets/1c9e79ac-12be-49df-bcbd-50c8b022abfe" />

### Phone View
<img width="2672" height="1521" alt="Screenshot 2026-05-01 at 9 04 21 PM" src="https://github.com/user-attachments/assets/111214aa-d5ae-4b62-867d-ccf6c4d0db0f" />

### Phone View
<img width="2672" height="1521" alt="Screenshot 2026-05-01 at 9 04 26 PM" src="https://github.com/user-attachments/assets/55447a66-2459-4c13-ae69-419a2e76fa32" />

### Phone View
<img width="2672" height="1521" alt="Screenshot 2026-05-01 at 9 04 43 PM" src="https://github.com/user-attachments/assets/dd85d2de-b955-4ae1-b7bf-187d7ac49015" />
