### PR TITLE
Add required indicators and validation for event fields and custom questions

### DIFF
--- a/src/Pages/Events/CreateEventFormQuestionBlock.js
+++ b/src/Pages/Events/CreateEventFormQuestionBlock.js
@@ -47,10 +47,11 @@ export default function CreateEventFormQuestionBlock({
 
       <label className="w-full mt-3 form-control">
         <div className="label">
-          <span className="label-text">Question text</span>
+          <span className="label-text">Question text *</span>
         </div>
         <input
           type="text"
+          required
           className="w-full text-sm input input-bordered sm:text-base"
           value={question.question}
           onChange={(e) => onUpdateField(question.id, 'question', e.target.value)}
@@ -83,6 +84,7 @@ export default function CreateEventFormQuestionBlock({
             <div key={`${question.id}-opt-${optIndex}`} className="flex gap-2 items-center">
               <input
                 type="text"
+                required
                 className="flex-1 text-sm input input-bordered input-sm"
                 value={option}
                 onChange={(e) => onUpdateAnswerOption(question.id, optIndex, e.target.value)}

--- a/src/Pages/Events/CreateEventPage.js
+++ b/src/Pages/Events/CreateEventPage.js
@@ -177,6 +177,19 @@ export default function CreateEventPage() {
       setSubmitError('Please enter an event name.');
       return;
     }
+    if (!date) {
+      setSubmitError('Please select an event date.');
+      return;
+    }
+
+    if (!time) {
+      setSubmitError('Please select an event time.');
+      return;
+    }
+    if (!location.trim()) {
+      setSubmitError('Please enter an event location.');
+      return;
+    }
     if (!adminId) {
       setSubmitError('Could not resolve your user id.');
       return;
@@ -206,6 +219,25 @@ export default function CreateEventPage() {
         'This event is marked published and also has a publish date. It may publish immediately if that date is in the past. Continue?'
       );
       if (!confirmed) return;
+    }
+
+    const hasBlankQuestion = questions.some((q) => !String(q.question || '').trim());
+
+    if (hasBlankQuestion) {
+      setSubmitError('Please fill out all registration question text fields.');
+      return;
+    }
+
+    const hasBlankAnswerOption = questions.some((q) =>
+      ['multiple_choice', 'dropdown', 'checkbox'].includes(q.type) &&
+      (!Array.isArray(q.answer_options) ||
+        q.answer_options.length === 0 ||
+        q.answer_options.some((opt) => !String(opt || '').trim()))
+    );
+
+    if (hasBlankAnswerOption) {
+      setSubmitError('Please fill out all answer options for choice questions.');
+      return;
     }
 
     const payload = {

--- a/src/Pages/Events/EditEventPage.js
+++ b/src/Pages/Events/EditEventPage.js
@@ -190,6 +190,21 @@ export default function EditEventPage() {
       return;
     }
 
+    if (!date) {
+      setSubmitError('Please select an event date.');
+      return;
+    }
+
+    if (!time) {
+      setSubmitError('Please select an event time.');
+      return;
+    }
+
+    if (!location.trim()) {
+      setSubmitError('Please enter an event location.');
+      return;
+    }
+
     if (visibility === 'private' && !minimumVisibleRole) {
       setSubmitError('Please select a minimum visible role for private events.');
       return;
@@ -222,6 +237,25 @@ export default function EditEventPage() {
         'This event is marked published and also has a publish date. It may publish immediately if that date is in the past. Continue?'
       );
       if (!confirmed) return;
+    }
+
+    const hasBlankQuestion = questions.some((q) => !String(q.question || '').trim());
+
+    if (hasBlankQuestion) {
+      setSubmitError('Please fill out all registration question text fields.');
+      return;
+    }
+
+    const hasBlankAnswerOption = questions.some((q) =>
+      ['multiple_choice', 'dropdown', 'checkbox'].includes(q.type) &&
+      (!Array.isArray(q.answer_options) ||
+        q.answer_options.length === 0 ||
+        q.answer_options.some((opt) => !String(opt || '').trim()))
+    );
+
+    if (hasBlankAnswerOption) {
+      setSubmitError('Please fill out all answer options for choice questions.');
+      return;
     }
 
     const payload = {

--- a/src/Pages/Events/EventEditorForm.js
+++ b/src/Pages/Events/EventEditorForm.js
@@ -82,6 +82,7 @@ export default function EventEditorForm({
           </div>
           <input
             type="text"
+            required
             className="input input-bordered w-full text-sm sm:text-base"
             value={eventName}
             onChange={(e) => setEventName(e.target.value)}
@@ -96,6 +97,7 @@ export default function EventEditorForm({
             </div>
             <input
               type="date"
+              required
               className="input input-bordered w-full"
               value={date}
               onChange={(e) => setDate(e.target.value)}
@@ -107,6 +109,7 @@ export default function EventEditorForm({
             </div>
             <input
               type="time"
+              required
               className="input input-bordered w-full"
               value={time}
               onChange={(e) => setTime(e.target.value)}
@@ -116,10 +119,11 @@ export default function EventEditorForm({
 
         <label className="form-control w-full">
           <div className="label">
-            <span className="label-text">Location</span>
+            <span className="label-text">Location *</span>
           </div>
           <input
             type="text"
+            required
             className="input input-bordered w-full text-sm sm:text-base"
             value={location}
             onChange={(e) => setLocation(e.target.value)}
@@ -302,9 +306,12 @@ export default function EventEditorForm({
         {visibility === 'private' && (
           <label className="form-control w-full">
             <div className="label">
-              <span className="label-text">Minimum visible role</span>
+              <span className="label-text">
+                Minimum visible role {visibility === 'private' && '*'}
+              </span>
             </div>
             <select
+              required={visibility === 'private'}
               className="select select-bordered w-full max-w-xs"
               value={minimumVisibleRole}
               onChange={(e) => setMinimumVisibleRole(e.target.value)}


### PR DESCRIPTION
### Changes
- Add `*` indicators for required event fields: name, date, time, location
- Show `*` for minimum visible role only when visibility is private
- Add required indicators for custom registration question text
- Validate blank custom question text and choice options before creating/editing events

### Screenshots
<img width="1920" height="885" alt="Screenshot 2026-05-02 at 8 55 32 PM" src="https://github.com/user-attachments/assets/6c08fe8a-a779-4832-8342-5a56241d46eb" />
<img width="1920" height="885" alt="Screenshot 2026-05-02 at 8 55 39 PM" src="https://github.com/user-attachments/assets/03794c18-08ba-4bdc-9ba2-d982420744b8" />
<img width="1920" height="994" alt="Screenshot 2026-05-02 at 10 29 43 PM" src="https://github.com/user-attachments/assets/31472822-561a-47f4-af0a-c34affe88e33" />