### PR TITLE
Switched SCEvents token reading to useSCE hook

### DIFF
--- a/src/Pages/Events/CreateEventPage.js
+++ b/src/Pages/Events/CreateEventPage.js
@@ -45,6 +45,7 @@ function userDisplayName(admin) {
 
 export default function CreateEventPage() {
   const { user } = useSCE();
+  const token = user?.token;
   const history = useHistory();
 
   const [eventId] = useState(() => crypto.randomUUID());
@@ -136,7 +137,6 @@ export default function CreateEventPage() {
 
   async function performAdminSearch(query) {
     setAdminSearching(true);
-    const token = window.localStorage.getItem('jwtToken');
     const result = await getAllUsers({ token, query, minRole: membershipState.OFFICER });
     setAdminSearching(false);
     if (result.error) {
@@ -262,7 +262,6 @@ export default function CreateEventPage() {
     };
 
     setSubmitting(true);
-    const token = window.localStorage.getItem('jwtToken');
     const result = await createSCEvent(token, payload);
     setSubmitting(false);
 

--- a/src/Pages/Events/EditEventPage.js
+++ b/src/Pages/Events/EditEventPage.js
@@ -20,6 +20,7 @@ function userDisplayName(admin) {
 export default function EditEventPage() {
   const { id } = useParams();
   const { user } = useSCE();
+  const token = user?.token;
   const history = useHistory();
 
   const [isLoading, setIsLoading] = useState(true);
@@ -79,7 +80,6 @@ export default function EditEventPage() {
     async function loadEvent() {
       setIsLoading(true);
 
-      const token = window.localStorage.getItem('jwtToken');
       const result = await getEventByID(id, token);
 
       setIsLoading(false);
@@ -122,7 +122,7 @@ export default function EditEventPage() {
     }
 
     loadEvent();
-  }, [id, userId]);
+  }, [id, token, userId]);
 
   function addEventAdmin(admin) {
     if (allOrgAdminsCanEdit) return;
@@ -148,7 +148,6 @@ export default function EditEventPage() {
 
   async function performAdminSearch(query) {
     setAdminSearching(true);
-    const token = window.localStorage.getItem('jwtToken');
     const result = await getAllUsers({ token, query, minRole: membershipState.OFFICER });
     setAdminSearching(false);
     if (result.error) {
@@ -278,7 +277,6 @@ export default function EditEventPage() {
     };
 
     setSubmitting(true);
-    const token = window.localStorage.getItem('jwtToken');
     const result = await updateSCEvent(id, token, payload);
     setSubmitting(false);
 
@@ -296,7 +294,6 @@ export default function EditEventPage() {
   async function handleConfirmDelete() {
     setDeleteError('');
     setDeleteSubmitting(true);
-    const token = window.localStorage.getItem('jwtToken');
     const result = await deleteSCEvent(id, token);
     setDeleteSubmitting(false);
     if (result.error) {

--- a/src/Pages/Events/Events.js
+++ b/src/Pages/Events/Events.js
@@ -42,6 +42,7 @@ function canUserSeeEvent(event, user) {
 
 export default function EventsPage() {
   const { user } = useSCE();
+  const token = user?.token;
   const [events, setEvents] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
@@ -124,7 +125,6 @@ export default function EventsPage() {
       setIsLoading(true);
       setHasError(false);
 
-      const token = window.localStorage.getItem('jwtToken');
       const startDate = toDateKey(new Date(cursor.getFullYear(), cursor.getMonth(), 1));
       const endDate = toDateKey(new Date(cursor.getFullYear(), cursor.getMonth() + 1, 0));
       const response = await getAllSCEvents(token, { startDate, endDate });
@@ -139,7 +139,7 @@ export default function EventsPage() {
     }
 
     fetchEvents();
-  }, [cursor]);
+  }, [cursor, token]);
 
   return (
     <div className={pageContainerClass}>

--- a/src/Pages/Events/EventsRegistration.js
+++ b/src/Pages/Events/EventsRegistration.js
@@ -37,6 +37,7 @@ function StatusPanel({ title, message, borderClass, textClass, onBack }) {
 
 export default function EventRegistration() {
   const { user } = useSCE();
+  const token = user?.token;
   const { id } = useParams();
   const history = useHistory();
   const [event, setEvent] = useState(null);
@@ -56,7 +57,6 @@ export default function EventRegistration() {
       setIsLoading(true);
       setHasError(false);
 
-      const token = window.localStorage.getItem('jwtToken');
       const response = await getEventByID(id, token);
 
       if (!response.error && response.responseData) {
@@ -72,14 +72,13 @@ export default function EventRegistration() {
       setIsLoading(false);
     }
     fetchEvent();
-  }, [id]);
+  }, [id, token]);
 
   useEffect(() => {
     if (!id) {
       return;
     }
     let isCurrent = true;
-    const token = window.localStorage.getItem('jwtToken');
     if (!token) {
       return;
     }
@@ -100,7 +99,7 @@ export default function EventRegistration() {
     return () => {
       isCurrent = false;
     };
-  }, [id]);
+  }, [id, token]);
 
   const handleInputChange = (fieldId, value, type) => {
     if (type === 'checkbox') {
@@ -120,7 +119,6 @@ export default function EventRegistration() {
     setSubmitError('');
     setSubmitSuccess('');
 
-    const token = window.localStorage.getItem('jwtToken');
     if (!token) {
       setSubmitError('You must be logged in to register for an event.');
       return;


### PR DESCRIPTION
# PR for #2133 

## Problem
Before, SCEvent files in Clark were reading a user's token from local storage. However, Clark already has a built in useSCE() hook to get information about a user.

## Solution
Go through each SCEvents file in clark that would access a user's token and switch it over to use useSCE().