### PR TITLE
Added pagination for getting event attendees in the dashboard

### DIFF
--- a/src/APIFunctions/SCEvents.js
+++ b/src/APIFunctions/SCEvents.js
@@ -151,7 +151,7 @@ export async function deleteSCEvent(id, token) {
   return status;
 }
 
-export async function getEventRegistrations(eventId, token, { limit = 50, offset = 0 } = {}) {
+export async function getEventRegistrations(eventId, token, { limit = 50, offset = 0, signal } = {}) {
   const status = new ApiResponse();
   try {
     const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
@@ -160,6 +160,7 @@ export async function getEventRegistrations(eventId, token, { limit = 50, offset
       headers: {
         Authorization: `Bearer ${token}`,
       },
+      ...(signal != null ? { signal } : {}),
     });
     const result = await res.json();
     status.responseData = result;
@@ -167,13 +168,17 @@ export async function getEventRegistrations(eventId, token, { limit = 50, offset
       status.error = true;
     }
   } catch (err) {
+    if (err?.name === 'AbortError') {
+      status.aborted = true;
+      return status;
+    }
     status.error = true;
     status.responseData = { error: err?.message || 'Failed to connect to SCEvents API' };
   }
   return status;
 }
 
-export async function getEventRegistrationByRequestId(eventId, requestId, token) {
+export async function getEventRegistrationByRequestId(eventId, requestId, token, signal) {
   const status = new ApiResponse();
   try {
     const url = new URL(`${SCEVENTS_API_URL}/events/${eventId}/registrations/${requestId}`, window.location.origin);
@@ -181,6 +186,7 @@ export async function getEventRegistrationByRequestId(eventId, requestId, token)
       headers: {
         Authorization: `Bearer ${token}`,
       },
+      ...(signal != null ? { signal } : {}),
     });
     const result = await res.json();
     status.responseData = result;
@@ -188,6 +194,10 @@ export async function getEventRegistrationByRequestId(eventId, requestId, token)
       status.error = true;
     }
   } catch (err) {
+    if (err?.name === 'AbortError') {
+      status.aborted = true;
+      return status;
+    }
     status.error = true;
     status.responseData = { error: err?.message || 'Failed to connect to SCEvents API' };
   }

--- a/src/Pages/Events/EventAttendeesDashboard.js
+++ b/src/Pages/Events/EventAttendeesDashboard.js
@@ -3,7 +3,7 @@ import { Link, Redirect, useParams } from 'react-router-dom';
 import { getEventByID, getEventRegistrationByRequestId, getEventRegistrations } from '../../APIFunctions/SCEvents';
 import { useSCE } from '../../Components/context/SceContext';
 
-const EVENT_REGISTRATIONS_PAGE_SIZE = 100;
+const EVENT_REGISTRATIONS_PAGE_SIZE = 10;
 
 function formatDateTime(dateValue) {
   if (!dateValue) return 'N/A';
@@ -44,6 +44,7 @@ export default function EventAttendeesDashboard() {
   const [isDetailOpen, setIsDetailOpen] = useState(false);
   const [event, setEvent] = useState(null);
   const [registrationsOffset, setRegistrationsOffset] = useState(0);
+  const [jumpPageDraft, setJumpPageDraft] = useState('1');
 
   useEffect(() => {
     if (!authenticated || !user?.token || !id) return;
@@ -93,6 +94,10 @@ export default function EventAttendeesDashboard() {
       controller.abort();
     };
   }, [authenticated, id, user?.token, registrationsOffset]);
+
+  useEffect(() => {
+    setJumpPageDraft(String(Math.floor(registrationsOffset / EVENT_REGISTRATIONS_PAGE_SIZE) + 1));
+  }, [registrationsOffset]);
 
   useEffect(() => {
     if (!selectedRequestId || !user?.token || !id) {
@@ -145,6 +150,17 @@ export default function EventAttendeesDashboard() {
     setRegistrationsOffset((prev) => prev + EVENT_REGISTRATIONS_PAGE_SIZE);
   }
 
+  function handleJumpToRegistrationsPage(event) {
+    event.preventDefault();
+    const total = summary.total || 0;
+    const totalPages = Math.max(1, Math.ceil(total / EVENT_REGISTRATIONS_PAGE_SIZE));
+    let page = parseInt(String(jumpPageDraft).trim(), 10);
+    if (!Number.isFinite(page) || page <= 0) page = 1;
+    else if (page > totalPages) page = totalPages;
+    setRegistrationsOffset((page - 1) * EVENT_REGISTRATIONS_PAGE_SIZE);
+    setJumpPageDraft(String(page));
+  }
+
   const selectedAnswers = useMemo(() => {
     if (!selectedAttendee?.answers || typeof selectedAttendee.answers !== 'object') return [];
 
@@ -167,6 +183,11 @@ export default function EventAttendeesDashboard() {
   if (!authenticated) return <Redirect to="/login" />;
 
   const registrationsTotal = summary.total || 0;
+  const registrationsTotalPages = Math.max(1, Math.ceil(registrationsTotal / EVENT_REGISTRATIONS_PAGE_SIZE));
+  const registrationsCurrentPage = Math.min(
+    registrationsTotalPages,
+    Math.floor(registrationsOffset / EVENT_REGISTRATIONS_PAGE_SIZE) + 1,
+  );
   const canPageRegistrationsPrev = registrationsOffset > 0;
   const canPageRegistrationsNext = registrationsOffset + attendees.length < registrationsTotal;
   const showRegistrationsPagination =
@@ -202,13 +223,18 @@ export default function EventAttendeesDashboard() {
               <p className="text-xs text-gray-300">Click an attendee to open details</p>
             </div>
             {showRegistrationsPagination && (
-              <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
-                <p className="text-xs text-gray-400">
-                  {attendees.length > 0
-                    ? `${registrationsOffset + 1}–${registrationsOffset + attendees.length} of ${registrationsTotal}`
-                    : `${registrationsTotal} total`}
-                </p>
-                <div className="flex gap-2">
+              <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
+                <div className="space-y-1 text-xs text-gray-400">
+                  <p>
+                    Page {registrationsCurrentPage} of {registrationsTotalPages}
+                  </p>
+                  <p>
+                    {attendees.length > 0
+                      ? `${registrationsOffset + 1}–${registrationsOffset + attendees.length} of ${registrationsTotal}`
+                      : `${registrationsTotal} total`}
+                  </p>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
                   <button
                     type="button"
                     className="rounded-lg border border-white/20 px-3 py-1.5 text-sm hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40"
@@ -225,6 +251,24 @@ export default function EventAttendeesDashboard() {
                   >
                     Next
                   </button>
+                  <form className="flex items-center gap-2" onSubmit={handleJumpToRegistrationsPage}>
+                    <input
+                      type="text"
+                      inputMode="numeric"
+                      aria-label="Go to page"
+                      value={jumpPageDraft}
+                      onChange={(e) => setJumpPageDraft(e.target.value)}
+                      className="w-14 rounded-lg border border-white/20 bg-black/20 px-2 py-1.5 text-center text-sm text-white"
+                      disabled={isLoadingList}
+                    />
+                    <button
+                      type="submit"
+                      className="rounded-lg border border-white/20 px-3 py-1.5 text-sm hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40"
+                      disabled={isLoadingList}
+                    >
+                      Go
+                    </button>
+                  </form>
                 </div>
               </div>
             )}

--- a/src/Pages/Events/EventAttendeesDashboard.js
+++ b/src/Pages/Events/EventAttendeesDashboard.js
@@ -3,6 +3,8 @@ import { Link, Redirect, useParams } from 'react-router-dom';
 import { getEventByID, getEventRegistrationByRequestId, getEventRegistrations } from '../../APIFunctions/SCEvents';
 import { useSCE } from '../../Components/context/SceContext';
 
+const EVENT_REGISTRATIONS_PAGE_SIZE = 100;
+
 function formatDateTime(dateValue) {
   if (!dateValue) return 'N/A';
   const date = new Date(dateValue);
@@ -41,6 +43,7 @@ export default function EventAttendeesDashboard() {
   const [detailError, setDetailError] = useState('');
   const [isDetailOpen, setIsDetailOpen] = useState(false);
   const [event, setEvent] = useState(null);
+  const [registrationsOffset, setRegistrationsOffset] = useState(0);
 
   useEffect(() => {
     if (!authenticated || !user?.token || !id) return;
@@ -56,12 +59,23 @@ export default function EventAttendeesDashboard() {
   }, [authenticated, id, user?.token]);
 
   useEffect(() => {
-    if (!authenticated || !user?.token || !id) return;
+    setRegistrationsOffset(0);
+  }, [id, user?.token]);
+
+  useEffect(() => {
+    if (!authenticated || !user?.token || !id) {
+      setIsLoadingList(false);
+      return;
+    }
+
+    let active = true;
+    const controller = new AbortController();
 
     async function fetchRegistrations() {
       setIsLoadingList(true);
       setListError('');
-      const response = await getEventRegistrations(id, user.token, { limit: 100, offset: 0 });
+      const response = await getEventRegistrations(id, user.token, { limit: EVENT_REGISTRATIONS_PAGE_SIZE, offset: registrationsOffset, signal: controller.signal });
+      if (!active || response.aborted) return;
       if (response.error) {
         setListError(response.responseData?.error || 'Failed to load attendees.');
         setAttendees([]);
@@ -74,15 +88,26 @@ export default function EventAttendeesDashboard() {
     }
 
     fetchRegistrations();
-  }, [authenticated, id, user?.token]);
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [authenticated, id, user?.token, registrationsOffset]);
 
   useEffect(() => {
-    if (!selectedRequestId || !user?.token) return;
+    if (!selectedRequestId || !user?.token || !id) {
+      setIsLoadingDetail(false);
+      return;
+    }
+
+    let active = true;
+    const controller = new AbortController();
 
     async function fetchAttendeeDetail() {
       setIsLoadingDetail(true);
       setDetailError('');
-      const response = await getEventRegistrationByRequestId(id, selectedRequestId, user.token);
+      const response = await getEventRegistrationByRequestId(id, selectedRequestId, user.token, controller.signal);
+      if (!active || response.aborted) return;
       if (response.error) {
         setDetailError(response.responseData?.error || 'Failed to load attendee details.');
         setSelectedAttendee(null);
@@ -93,6 +118,10 @@ export default function EventAttendeesDashboard() {
     }
 
     fetchAttendeeDetail();
+    return () => {
+      active = false;
+      controller.abort();
+    };
   }, [id, selectedRequestId, user?.token]);
 
   useEffect(() => {
@@ -106,6 +135,14 @@ export default function EventAttendeesDashboard() {
 
   function closeDetailPanel() {
     setIsDetailOpen(false);
+  }
+
+  function handleRegistrationsPrevPage() {
+    setRegistrationsOffset((prev) => Math.max(0, prev - EVENT_REGISTRATIONS_PAGE_SIZE));
+  }
+
+  function handleRegistrationsNextPage() {
+    setRegistrationsOffset((prev) => prev + EVENT_REGISTRATIONS_PAGE_SIZE);
   }
 
   const selectedAnswers = useMemo(() => {
@@ -128,6 +165,12 @@ export default function EventAttendeesDashboard() {
   }, [selectedAttendee, event]);
 
   if (!authenticated) return <Redirect to="/login" />;
+
+  const registrationsTotal = summary.total || 0;
+  const canPageRegistrationsPrev = registrationsOffset > 0;
+  const canPageRegistrationsNext = registrationsOffset + attendees.length < registrationsTotal;
+  const showRegistrationsPagination =
+    registrationsTotal > EVENT_REGISTRATIONS_PAGE_SIZE || registrationsOffset > 0;
 
   return (
     <div className="min-h-screen bg-gradient-to-r from-gray-800 to-gray-600 px-6 py-10 text-white">
@@ -158,6 +201,33 @@ export default function EventAttendeesDashboard() {
               <h2 className="text-lg font-semibold">Attendees</h2>
               <p className="text-xs text-gray-300">Click an attendee to open details</p>
             </div>
+            {showRegistrationsPagination && (
+              <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+                <p className="text-xs text-gray-400">
+                  {attendees.length > 0
+                    ? `${registrationsOffset + 1}–${registrationsOffset + attendees.length} of ${registrationsTotal}`
+                    : `${registrationsTotal} total`}
+                </p>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    className="rounded-lg border border-white/20 px-3 py-1.5 text-sm hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40"
+                    disabled={isLoadingList || !canPageRegistrationsPrev}
+                    onClick={handleRegistrationsPrevPage}
+                  >
+                    Previous
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-lg border border-white/20 px-3 py-1.5 text-sm hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40"
+                    disabled={isLoadingList || !canPageRegistrationsNext}
+                    onClick={handleRegistrationsNextPage}
+                  >
+                    Next
+                  </button>
+                </div>
+              </div>
+            )}
             {attendees.length === 0 ? (
               <p className="text-sm text-gray-300">No attendees found for this event yet.</p>
             ) : (


### PR DESCRIPTION
# PR for #2117 

## **Problem**
The `EventAttendeesDashboard` previously lacked pagination support, making it difficult to manage and view attendees for events with a large number of registrations. Furthermore, the dashboard was susceptible to race conditions and unnecessary network traffic when users interacted with the interface quickly, as there was no mechanism to cancel outdated API requests.

## **Solution**
*   **Implemented Pagination**: Introduced `registrationsOffset` state to track the current page and added "Previous" and "Next" navigation controls. The dashboard now fetches attendees in batches of 100.
*   **Added Request Cancellation**: Integrated `AbortController` into the data-fetching hooks. This ensures that if a user navigates away or triggers a new fetch before the previous one completes, the outdated request is cancelled to prevent state inconsistencies.
*   **Enhanced API Functions**: Updated `getEventRegistrations` and `getEventRegistrationByRequestId` in the SCEvents API utility to accept and respect `AbortSignal`.
*   **Improved UI Feedback**: Added a pagination status indicator (e.g., "1–100 of 500") and ensured navigation buttons are appropriately disabled during loading or when at the boundaries of the list.

## **Files Changed**
*   `src/APIFunctions/SCEvents.js`: Updated API call wrappers to support request aborting and handle `AbortError` gracefully.
*   `src/Pages/Events/EventAttendeesDashboard.js`: Implemented pagination logic, navigation handlers, and request lifecycle management with `AbortController`.

## Screenshots

### First Page
<img width="1023" height="217" alt="Screenshot 2026-05-04 at 8 13 51 PM" src="https://github.com/user-attachments/assets/0cd7427e-36bd-406e-8bf8-6ae984b04746" />

### Second Page
<img width="1023" height="230" alt="Screenshot 2026-05-04 at 8 14 19 PM" src="https://github.com/user-attachments/assets/af2393c2-4caf-450e-9285-111866c6ab40" />

